### PR TITLE
루틴 데이터 레이어 생성 기능 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     annotationProcessor("androidx.room:room-compiler:$roomVersion")
     kapt("androidx.room:room-compiler:$roomVersion")
     implementation("androidx.room:room-paging:$roomVersion")
+    implementation("androidx.room:room-ktx:$roomVersion")
 
     //navigation
     val navVersion = "2.5.3"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,6 +30,7 @@ android {
         }
     }
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -88,4 +89,7 @@ dependencies {
 
     //google
     implementation("com.google.android.gms:play-services-auth:20.3.0")
+
+    // desugar
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.2.0")
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/database/AppDatabase.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/AppDatabase.kt
@@ -1,0 +1,20 @@
+package com.lateinit.rightweight.data.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.lateinit.rightweight.data.database.dao.RoutineDao
+import com.lateinit.rightweight.data.database.entity.Day
+import com.lateinit.rightweight.data.database.entity.Exercise
+import com.lateinit.rightweight.data.database.entity.Routine
+import com.lateinit.rightweight.data.database.entity.Set
+
+@Database(
+    entities = [Routine::class, Day::class, Exercise::class, Set::class],
+    version = 1,
+    exportSchema = false
+)
+@TypeConverters(Converters::class)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun routineDao(): RoutineDao
+}

--- a/app/src/main/java/com/lateinit/rightweight/data/database/Converters.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/Converters.kt
@@ -1,0 +1,19 @@
+package com.lateinit.rightweight.data.database
+
+import androidx.room.TypeConverter
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class Converters {
+
+    @TypeConverter
+    fun toLocalDateTime(timestamp: Long): LocalDateTime {
+        return Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).toLocalDateTime()
+    }
+
+    @TypeConverter
+    fun toTimestamp(date: LocalDateTime): Long {
+        return date.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    }
+}

--- a/app/src/main/java/com/lateinit/rightweight/data/database/dao/RoutineDao.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/dao/RoutineDao.kt
@@ -1,0 +1,37 @@
+package com.lateinit.rightweight.data.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import com.lateinit.rightweight.data.database.entity.Day
+import com.lateinit.rightweight.data.database.entity.Exercise
+import com.lateinit.rightweight.data.database.entity.Routine
+import com.lateinit.rightweight.data.database.entity.Set
+
+@Dao
+interface RoutineDao {
+
+    suspend fun insertRoutine(
+        routine: Routine,
+        days: List<Day>,
+        exercises: List<Exercise>,
+        sets: List<Set>
+    ) {
+        insertRoutineInfo(routine)
+        insertDays(days)
+        insertExercises(exercises)
+        insertSets(sets)
+    }
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertRoutineInfo(routine: Routine)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertDays(days: List<Day>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertExercises(exercises: List<Exercise>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSets(sets: List<Set>)
+}

--- a/app/src/main/java/com/lateinit/rightweight/data/database/entity/Day.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/entity/Day.kt
@@ -1,0 +1,28 @@
+package com.lateinit.rightweight.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.ForeignKey.CASCADE
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "day",
+    foreignKeys = [
+        ForeignKey(
+            entity = Routine::class,
+            parentColumns = ["routine_id"],
+            childColumns = ["routine_id"],
+            onDelete = CASCADE
+        )
+    ]
+)
+data class Day(
+    @PrimaryKey
+    @ColumnInfo(name = "day_id")
+    val dayId: String,
+    @ColumnInfo(name = "routine_id")
+    val routineId: String,
+    @ColumnInfo(name = "order")
+    val order: Long,
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/database/entity/Exercise.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/entity/Exercise.kt
@@ -1,0 +1,32 @@
+package com.lateinit.rightweight.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.ForeignKey.CASCADE
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "exercise",
+    foreignKeys = [
+        ForeignKey(
+            entity = Day::class,
+            parentColumns = ["day_id"],
+            childColumns = ["day_id"],
+            onDelete = CASCADE
+        )
+    ]
+)
+data class Exercise(
+    @PrimaryKey
+    @ColumnInfo(name = "exercise_id")
+    val exerciseId: String,
+    @ColumnInfo(name = "day_id")
+    val dayId: String,
+    @ColumnInfo(name = "title")
+    val title: String,
+    @ColumnInfo(name = "order")
+    val order: Long,
+    @ColumnInfo(name = "part")
+    val part: String,
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/database/entity/Routine.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/entity/Routine.kt
@@ -1,0 +1,21 @@
+package com.lateinit.rightweight.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.time.LocalDateTime
+
+@Entity(tableName = "routine")
+data class Routine(
+    @PrimaryKey
+    @ColumnInfo(name = "routine_id")
+    val routineId: String,
+    @ColumnInfo(name = "title")
+    val title: String,
+    @ColumnInfo(name = "author")
+    val author: String,
+    @ColumnInfo(name = "description")
+    val description: String,
+    @ColumnInfo(name = "modified_date")
+    val modifiedDate: LocalDateTime,
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/database/entity/Set.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/entity/Set.kt
@@ -1,0 +1,32 @@
+package com.lateinit.rightweight.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.ForeignKey.CASCADE
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "set",
+    foreignKeys = [
+        ForeignKey(
+            entity = Exercise::class,
+            parentColumns = ["exercise_id"],
+            childColumns = ["exercise_id"],
+            onDelete = CASCADE
+        )
+    ]
+)
+data class Set(
+    @PrimaryKey
+    @ColumnInfo(name = "set_id")
+    val setId: String,
+    @ColumnInfo(name = "exercise_id")
+    val exerciseId: String,
+    @ColumnInfo(name = "weight")
+    val weight: Int,
+    @ColumnInfo(name = "number")
+    val number: Int,
+    @ColumnInfo(name = "order")
+    val order: Long,
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineDataSource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineDataSource.kt
@@ -1,0 +1,16 @@
+package com.lateinit.rightweight.data.datasource
+
+import com.lateinit.rightweight.data.database.entity.Day
+import com.lateinit.rightweight.data.database.entity.Exercise
+import com.lateinit.rightweight.data.database.entity.Routine
+import com.lateinit.rightweight.data.database.entity.Set
+
+interface RoutineDataSource {
+
+    suspend fun insertRoutine(
+        routine: Routine,
+        days: List<Day>,
+        exercises: List<Exercise>,
+        sets: List<Set>
+    )
+}

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineLocalDataSource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineLocalDataSource.kt
@@ -1,0 +1,21 @@
+package com.lateinit.rightweight.data.datasource
+
+import com.lateinit.rightweight.data.database.dao.RoutineDao
+import com.lateinit.rightweight.data.database.entity.Day
+import com.lateinit.rightweight.data.database.entity.Exercise
+import com.lateinit.rightweight.data.database.entity.Routine
+import com.lateinit.rightweight.data.database.entity.Set
+import javax.inject.Inject
+
+class RoutineLocalDataSource @Inject constructor(private val routineDao: RoutineDao) :
+    RoutineDataSource {
+
+    override suspend fun insertRoutine(
+        routine: Routine,
+        days: List<Day>,
+        exercises: List<Exercise>,
+        sets: List<Set>
+    ) {
+        routineDao.insertRoutine(routine, days, exercises, sets)
+    }
+}

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/RoutineRepository.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/RoutineRepository.kt
@@ -1,0 +1,16 @@
+package com.lateinit.rightweight.data.repository
+
+import com.lateinit.rightweight.data.database.entity.Day
+import com.lateinit.rightweight.data.database.entity.Exercise
+import com.lateinit.rightweight.data.database.entity.Routine
+import com.lateinit.rightweight.data.database.entity.Set
+
+interface RoutineRepository {
+
+    suspend fun insertRoutine(
+        routine: Routine,
+        days: List<Day>,
+        exercises: List<Exercise>,
+        sets: List<Set>
+    )
+}

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/RoutineRepositoryImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/RoutineRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.lateinit.rightweight.data.repository
+
+import com.lateinit.rightweight.data.database.entity.Day
+import com.lateinit.rightweight.data.database.entity.Exercise
+import com.lateinit.rightweight.data.database.entity.Routine
+import com.lateinit.rightweight.data.database.entity.Set
+import com.lateinit.rightweight.data.datasource.RoutineDataSource
+import javax.inject.Inject
+
+class RoutineRepositoryImpl @Inject constructor(
+    private val routineLocalDataSource: RoutineDataSource
+) : RoutineRepository {
+
+    override suspend fun insertRoutine(
+        routine: Routine,
+        days: List<Day>,
+        exercises: List<Exercise>,
+        sets: List<Set>,
+    ) {
+        routineLocalDataSource.insertRoutine(routine, days, exercises, sets)
+    }
+}

--- a/app/src/main/java/com/lateinit/rightweight/di/DataSourceModule.kt
+++ b/app/src/main/java/com/lateinit/rightweight/di/DataSourceModule.kt
@@ -1,10 +1,10 @@
 package com.lateinit.rightweight.di
 
 import com.lateinit.rightweight.data.RightWeightRetrofitService
+import com.lateinit.rightweight.data.database.dao.RoutineDao
 import com.lateinit.rightweight.data.datasource.LoginDataSource
 import com.lateinit.rightweight.data.datasource.LoginDataSourceImpl
-import com.lateinit.rightweight.data.repository.LoginRepository
-import com.lateinit.rightweight.data.repository.LoginRepositoryImpl
+import com.lateinit.rightweight.data.datasource.RoutineLocalDataSource
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -21,5 +21,11 @@ class DataSourceModule {
         api: RightWeightRetrofitService
     ): LoginDataSource {
         return LoginDataSourceImpl(api)
+    }
+
+    @Provides
+    @Singleton
+    fun getRoutineLocalDataSource(routineDao: RoutineDao): RoutineLocalDataSource {
+        return RoutineLocalDataSource(routineDao)
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/di/DatabaseModule.kt
+++ b/app/src/main/java/com/lateinit/rightweight/di/DatabaseModule.kt
@@ -1,0 +1,33 @@
+package com.lateinit.rightweight.di
+
+import android.content.Context
+import androidx.room.Room
+import com.lateinit.rightweight.data.database.AppDatabase
+import com.lateinit.rightweight.data.database.dao.RoutineDao
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class DatabaseModule {
+
+    @Provides
+    @Singleton
+    fun getAppDatabase(@ApplicationContext context: Context): AppDatabase {
+        return Room.databaseBuilder(context, AppDatabase::class.java, DB_NAME).build()
+    }
+
+    @Provides
+    @Singleton
+    fun getRoutineDao(appDatabase: AppDatabase): RoutineDao {
+        return appDatabase.routineDao()
+    }
+
+    companion object {
+        private const val DB_NAME = "right_weight.db"
+    }
+}

--- a/app/src/main/java/com/lateinit/rightweight/di/RepositoryModule.kt
+++ b/app/src/main/java/com/lateinit/rightweight/di/RepositoryModule.kt
@@ -1,9 +1,11 @@
 package com.lateinit.rightweight.di
 
-import com.lateinit.rightweight.data.RightWeightRetrofitService
 import com.lateinit.rightweight.data.datasource.LoginDataSource
+import com.lateinit.rightweight.data.datasource.RoutineLocalDataSource
 import com.lateinit.rightweight.data.repository.LoginRepository
 import com.lateinit.rightweight.data.repository.LoginRepositoryImpl
+import com.lateinit.rightweight.data.repository.RoutineRepository
+import com.lateinit.rightweight.data.repository.RoutineRepositoryImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -20,5 +22,13 @@ class RepositoryModule {
         loginDataSource: LoginDataSource
     ): LoginRepository {
         return LoginRepositoryImpl(loginDataSource)
+    }
+
+    @Provides
+    @Singleton
+    fun getRoutineRepository(
+        routineLocalDataSource: RoutineLocalDataSource
+    ): RoutineRepository {
+        return RoutineRepositoryImpl(routineLocalDataSource)
     }
 }


### PR DESCRIPTION
- close #7 

## 작업 내용

- room-ktx dependency 추가
- core library desugaring 추가
    - `java.time` 하위 클래스를 api level 26 하위 버전에서 지원하기 위함
- Room Database 추가
- 루틴 관련 엔티티 클래스 추가
- Database에 사용할 Type Converter 추가 및 적용
- 루틴 Dao 생성 기능 구현
- 루틴 Repository 생성 기능 구현
- 루틴 LocalDataSource 생성 기능 구현
- 루틴 관련 di module 구성