### PR TITLE
[로그인/홈화면] 코드개선

### DIFF
--- a/app/src/main/java/com/lateinit/rightweight/data/database/AppSharedPreferences.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/AppSharedPreferences.kt
@@ -4,16 +4,18 @@ import android.content.Context
 import android.content.SharedPreferences
 import com.google.gson.Gson
 import com.lateinit.rightweight.R
+import com.lateinit.rightweight.data.LoginResponse
 import com.lateinit.rightweight.data.model.User
 
 class AppSharedPreferences(context: Context) {
 
     private val userKey = "userInfo"
+    private val loginResponseKey = "loginResponse"
     private val sharedPreferences: SharedPreferences =
         context.getSharedPreferences(context.getString(R.string.app_name), Context.MODE_PRIVATE)
 
-    fun setUser(user: User) {
-        sharedPreferences.edit().putString(userKey, Gson().toJson(user)).commit()
+    fun setUser(user: User?) {
+        sharedPreferences.edit().putString(userKey, Gson().toJson(user)).apply()
     }
 
     fun getUser(): User {
@@ -21,5 +23,16 @@ class AppSharedPreferences(context: Context) {
             sharedPreferences.getString(userKey, null),
             User::class.java
         ) ?: User(null, null, null)
+    }
+
+    fun setLoginResponse(loginResponse: LoginResponse?) {
+        sharedPreferences.edit().putString(loginResponseKey, Gson().toJson(loginResponse)).apply()
+    }
+
+    fun getLoginResponse(): LoginResponse? {
+        return Gson().fromJson(
+            sharedPreferences.getString(loginResponseKey, null),
+            LoginResponse::class.java
+        )
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/UserDataSource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/UserDataSource.kt
@@ -1,8 +1,11 @@
 package com.lateinit.rightweight.data.datasource
 
+import com.lateinit.rightweight.data.LoginResponse
 import com.lateinit.rightweight.data.model.User
 
 interface UserDataSource {
-    suspend fun setUser(user: User)
+    suspend fun setUser(user: User?)
     suspend fun getUser(): User
+    fun setLoginResponse(loginResponse: LoginResponse?)
+    fun getLoginResponse(): LoginResponse?
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/UserLocalDataSource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/UserLocalDataSource.kt
@@ -1,16 +1,25 @@
 package com.lateinit.rightweight.data.datasource
 
+import com.lateinit.rightweight.data.LoginResponse
 import com.lateinit.rightweight.data.database.AppSharedPreferences
 import com.lateinit.rightweight.data.model.User
 import javax.inject.Inject
 
 class UserLocalDataSource @Inject constructor(private val appSharedPreferences: AppSharedPreferences) :
     UserDataSource {
-    override suspend fun setUser(user: User) {
+    override suspend fun setUser(user: User?) {
         appSharedPreferences.setUser(user)
     }
 
     override suspend fun getUser(): User {
         return appSharedPreferences.getUser()
+    }
+
+    override fun setLoginResponse(loginResponse: LoginResponse?) {
+        appSharedPreferences.setLoginResponse(loginResponse)
+    }
+
+    override fun getLoginResponse(): LoginResponse? {
+        return getLoginResponse()
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/UserLocalDataSource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/UserLocalDataSource.kt
@@ -20,6 +20,6 @@ class UserLocalDataSource @Inject constructor(private val appSharedPreferences: 
     }
 
     override fun getLoginResponse(): LoginResponse? {
-        return getLoginResponse()
+        return appSharedPreferences.getLoginResponse()
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/UserRepository.kt
@@ -1,8 +1,11 @@
 package com.lateinit.rightweight.data.repository
 
+import com.lateinit.rightweight.data.LoginResponse
 import com.lateinit.rightweight.data.model.User
 
 interface UserRepository {
-    suspend fun setUser(user: User)
+    suspend fun setUser(user: User?)
     suspend fun getUser(): User
+    suspend fun setLoginResponse(loginResponse: LoginResponse?)
+    suspend fun getLoginResponse(): LoginResponse?
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/UserRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.lateinit.rightweight.data.repository
 
+import com.lateinit.rightweight.data.LoginResponse
 import com.lateinit.rightweight.data.datasource.UserDataSource
 import com.lateinit.rightweight.data.model.User
 import javax.inject.Inject
@@ -7,11 +8,19 @@ import javax.inject.Inject
 class UserRepositoryImpl @Inject constructor(
     val userDataSource: UserDataSource
 ) : UserRepository {
-    override suspend fun setUser(user: User) {
+    override suspend fun setUser(user: User?) {
         userDataSource.setUser(user)
     }
 
     override suspend fun getUser(): User {
         return userDataSource.getUser()
+    }
+
+    override suspend fun setLoginResponse(loginResponse: LoginResponse?) {
+        userDataSource.setLoginResponse(loginResponse)
+    }
+
+    override suspend fun getLoginResponse(): LoginResponse? {
+        return userDataSource.getLoginResponse()
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/home/HomeActivity.kt
@@ -49,13 +49,6 @@ class HomeActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
         setActionBar()
         setNavController()
-
-        userViewModel.getLoginResponse()
-        userViewModel.loginResponse.observe(this) { loginResponse ->
-            NavigationHeaderBinding.bind(binding.navigationView.getHeaderView(0)).also {
-                it.loginResponse = loginResponse
-            }
-        }
     }
 
 
@@ -126,6 +119,15 @@ class HomeActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
             binding.drawerLayout
         )
         setSupportActionBar(binding.materialToolbar)
+
+        // set drawer header
+        userViewModel.getLoginResponse()
+        userViewModel.loginResponse.observe(this) { loginResponse ->
+            NavigationHeaderBinding.bind(binding.navigationView.getHeaderView(0)).also {
+                it.loginResponse = loginResponse
+            }
+        }
+
         binding.navigationView.setNavigationItemSelectedListener(this)
 
         // disable drawer swipe gesture

--- a/app/src/main/java/com/lateinit/rightweight/ui/home/HomeBindingAdapter.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/home/HomeBindingAdapter.kt
@@ -3,6 +3,7 @@ package com.lateinit.rightweight.ui.home
 import android.widget.ImageView
 import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
+import com.lateinit.rightweight.R
 
 @BindingAdapter(
     value = ["imageUrl"]
@@ -10,5 +11,6 @@ import com.bumptech.glide.Glide
 fun ImageView.setImage(imageUrl: String){
     Glide.with(this)
         .load(imageUrl)
+        .error(R.drawable.ic_launcher_foreground)
         .into(this)
 }

--- a/app/src/main/java/com/lateinit/rightweight/ui/home/UserViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/home/UserViewModel.kt
@@ -1,5 +1,6 @@
 package com.lateinit.rightweight.ui.home
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -24,6 +25,8 @@ class UserViewModel @Inject constructor(
     val userInfo: LiveData<User> get() = _userInfo
     private val _routine = MutableLiveData<Routine>()
     val routine: LiveData<Routine> get() = _routine
+    private val _loginResponse = MutableLiveData<LoginResponse>()
+    val loginResponse: LiveData<LoginResponse> get() = _loginResponse
 
     init {
         getUser()
@@ -34,6 +37,12 @@ class UserViewModel @Inject constructor(
         viewModelScope.launch {
             val days: List<Day> = routineRepository.getDaysByRoutineId(routineId)
             userRepository.setUser(User(user.userId, routineId, days[0].dayId))
+        }
+    }
+
+    fun setUser(user: User?) {
+        viewModelScope.launch {
+            userRepository.setUser(user)
         }
     }
 
@@ -59,15 +68,20 @@ class UserViewModel @Inject constructor(
         }
     }
 
-    fun setLoginResponse(loginResponse: LoginResponse) {
+    fun setLoginResponse(loginResponse: LoginResponse?) {
         viewModelScope.launch {
             userRepository.setLoginResponse(loginResponse)
         }
     }
 
-    fun setUser(user: User) {
+    fun getLoginResponse() {
         viewModelScope.launch {
-            userRepository.setUser(user)
+            val loginResponse = userRepository.getLoginResponse()
+            Log.d("UserViewModel", "loginResponse $loginResponse")
+            loginResponse?.let {
+                _loginResponse.postValue(it)
+            }
         }
     }
+
 }

--- a/app/src/main/java/com/lateinit/rightweight/ui/home/UserViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/home/UserViewModel.kt
@@ -1,6 +1,5 @@
 package com.lateinit.rightweight.ui.home
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -77,7 +76,6 @@ class UserViewModel @Inject constructor(
     fun getLoginResponse() {
         viewModelScope.launch {
             val loginResponse = userRepository.getLoginResponse()
-            Log.d("UserViewModel", "loginResponse $loginResponse")
             loginResponse?.let {
                 _loginResponse.postValue(it)
             }

--- a/app/src/main/java/com/lateinit/rightweight/ui/home/UserViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/home/UserViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.lateinit.rightweight.data.LoginResponse
 import com.lateinit.rightweight.data.database.entity.Day
 import com.lateinit.rightweight.data.database.entity.Routine
 import com.lateinit.rightweight.data.model.User
@@ -55,6 +56,18 @@ class UserViewModel @Inject constructor(
 
             val routine = routineRepository.getRoutineById(routineId)
             _routine.postValue(routine)
+        }
+    }
+
+    fun setLoginResponse(loginResponse: LoginResponse) {
+        viewModelScope.launch {
+            userRepository.setLoginResponse(loginResponse)
+        }
+    }
+
+    fun setUser(user: User) {
+        viewModelScope.launch {
+            userRepository.setUser(user)
         }
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/login/LoginActivity.kt
@@ -1,10 +1,7 @@
 package com.lateinit.rightweight.ui.login
 
-import android.content.Context
 import android.content.Intent
-import android.content.SharedPreferences
 import android.os.Bundle
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
@@ -17,11 +14,11 @@ import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
 import com.google.android.material.snackbar.Snackbar
-import com.google.gson.Gson
 import com.lateinit.rightweight.R
 import com.lateinit.rightweight.data.model.User
 import com.lateinit.rightweight.databinding.ActivityLoginBinding
 import com.lateinit.rightweight.ui.home.HomeActivity
+import com.lateinit.rightweight.ui.home.UserViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -30,9 +27,8 @@ import kotlinx.coroutines.launch
 class LoginActivity : AppCompatActivity() {
 
     lateinit var binding: ActivityLoginBinding
-    val viewModel: LoginViewModel by viewModels()
-
-    lateinit var sharedPreferences: SharedPreferences
+    val loginViewModel: LoginViewModel by viewModels()
+    val userViewModel: UserViewModel by viewModels()
 
     val getGoogleLoginResultText =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -50,23 +46,16 @@ class LoginActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Log.d(this.toString(), "onCreate")
         val options = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
             .requestIdToken(getString(R.string.default_web_client_id))
             .requestEmail().build()
         val client = GoogleSignIn.getClient(applicationContext, options)
 
         client.silentSignIn().addOnSuccessListener {
-            Log.d("LoginActivity", "success")
             val intent = Intent(baseContext, HomeActivity::class.java)
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
             startActivity(intent)
         }
-
-        sharedPreferences = baseContext.getSharedPreferences(
-            baseContext.getString(R.string.app_name),
-            Context.MODE_PRIVATE
-        )
 
         binding = ActivityLoginBinding.inflate(layoutInflater)
 
@@ -79,17 +68,14 @@ class LoginActivity : AppCompatActivity() {
 
         lifecycleScope.launch() {
             repeatOnLifecycle(Lifecycle.State.CREATED) {
-                viewModel.loginResponse.collect() { loginResponse ->
+                loginViewModel.loginResponse.collect() { loginResponse ->
                     if (loginResponse != null) {
-                        sharedPreferences.edit()
-                            .putString("loginResponse", Gson().toJson(loginResponse)).apply()
+                        userViewModel.setLoginResponse(loginResponse)
 
-                        val userInfo = sharedPreferences.getString("userInfo", null)
-                        if (userInfo == null) {
-                            sharedPreferences.edit().putString(
-                                "userInfo",
-                                Gson().toJson(User(loginResponse.localId, null, null))
-                            ).apply()
+                        userViewModel.userInfo.value ?: run {
+                            loginResponse.localId?.let { localId ->
+                                userViewModel.setUser(User(localId, null, null))
+                            }
                         }
                     }
                 }
@@ -100,11 +86,7 @@ class LoginActivity : AppCompatActivity() {
             val lifecycleScopeInstance = this
             repeatOnLifecycle(Lifecycle.State.CREATED) {
                 val repeatOnLifecycleInstance = this
-                Log.d("call", "")
-                viewModel.networkResult.collect() { networkResult ->
-                    Log.d("NetworkResult", networkResult.toString())
-                    Log.d("lifecycleScope", lifecycleScopeInstance.toString())
-                    Log.d("repeatOnLifecycle", repeatOnLifecycleInstance.toString())
+                loginViewModel.networkResult.collect() { networkResult ->
                     when (networkResult) {
                         NetworkState.NO_ERROR -> {
                             val intent = Intent(baseContext, HomeActivity::class.java)
@@ -132,27 +114,7 @@ class LoginActivity : AppCompatActivity() {
 
     fun loginToFireBase(idToken: String?) {
         idToken?.let {
-            viewModel.loginToFirebase(getString(R.string.google_api_key), idToken)
+            loginViewModel.loginToFirebase(getString(R.string.google_api_key), idToken)
         }
-    }
-
-    override fun onResume() {
-        super.onResume()
-        Log.d(this.toString(), "onResume")
-    }
-
-    override fun onPause() {
-        super.onPause()
-        Log.d(this.toString(), "onPause")
-    }
-
-    override fun onStop() {
-        super.onStop()
-        Log.d(this.toString(), "onStop")
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        Log.d(this.toString(), "onDestroy")
     }
 }

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -13,7 +13,7 @@
             android:layout_height="match_parent"
             tools:context=".ui.home.HomeActivity">
 
-            <androidx.appcompat.widget.Toolbar
+            <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/material_toolbar"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -18,7 +18,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="116dp"
-            android:text="Right Weight"
+            android:text="@string/app_name"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">RightWeight</string>
+    <string name="app_name">Right Weight</string>
     <string name="home">홈</string>
     <string name="calendar">달력</string>
     <string name="share">공유</string>


### PR DESCRIPTION
## 관련 이슈
- close #50 

## 작업내용

- sharedpreferences 접근 방식 변경
- 중복 제거, 코드 분리

- Activity에서는 바인딩에 null 처리 삭제

Fragment같은 경우는 프래그먼트가 뷰보다 오래 살아있을 수 있어서 onDestroyView에서 _binding = null 필요,
Activity같은 경우는 액티비티 자체가 뷰보다 오래 살아있지 않아서 널처리 불필요

https://developer.android.com/topic/libraries/view-binding?hl=ko