### PR TITLE
[홈 액티비티] edittext 포커스 관리, 키보드 화면 조정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         tools:targetApi="31">
         <activity
             android:name=".ui.home.HomeActivity"
-            android:exported="true">
+            android:exported="true"
+            android:windowSoftInputMode="adjustPan">
 
             <meta-data
                 android:name="android.app.lib_name"

--- a/app/src/main/java/com/lateinit/rightweight/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/home/HomeActivity.kt
@@ -1,9 +1,14 @@
 package com.lateinit.rightweight.ui.home
 
+import android.content.Context
 import android.content.Intent
+import android.graphics.Rect
 import android.os.Bundle
 import android.view.MenuItem
+import android.view.MotionEvent
 import android.view.View
+import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -167,5 +172,28 @@ class HomeActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
     private fun withdraw() {
         Toast.makeText(this, "회원 탈퇴", Toast.LENGTH_SHORT).show()
+    }
+
+    override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
+        when (event?.action) {
+            MotionEvent.ACTION_DOWN -> {
+                val focusView = currentFocus
+                if (focusView is EditText) {
+                    val outRect = Rect()
+                    focusView.getGlobalVisibleRect(outRect)
+                    if (!outRect.contains(event.rawX.toInt(), event.rawY.toInt())) {
+                        focusView.clearFocus()
+                        hideKeyboard(focusView)
+                    }
+                }
+            }
+        }
+        return super.dispatchTouchEvent(event)
+    }
+
+    private fun hideKeyboard(focusView: View) {
+        val inputMethodManager: InputMethodManager =
+            getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        inputMethodManager.hideSoftInputFromWindow(focusView.windowToken, 0)
     }
 }

--- a/app/src/main/res/layout/fragment_routine_editor.xml
+++ b/app/src/main/res/layout/fragment_routine_editor.xml
@@ -143,6 +143,7 @@
                     style="@style/Text.Small.Bold"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_marginBottom="300dp"
                     android:backgroundTint="@color/secondaryColor"
                     android:onClick="@{()->viewModel.addExercise()}"
                     android:padding="16dp"


### PR DESCRIPTION
- close #64 

## 동작 화면

https://user-images.githubusercontent.com/54586491/204142357-7a6cc663-d677-4758-869e-13016d175be8.mp4



## 작업 내용

- editText 바깥 영역이 눌리면 포커스가 제거되고 키보드가 내려 가도록 구현
- 처음엔 editor 프래그먼트에서만 작업 하려 했으나 다른 화면(운동시작)에서도 edittext를 사용하므로 액티비티에서 구현
- editor 프래그먼트에서 운동이 추가되어도 아래쪽 스크롤 여유를 주기 위해 margin_bottom값을 부여