### PR TITLE
[루틴 생성/수정 화면] Day 삭제, 추가 시 발생하는 버그 수정

### DIFF
--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/editor/RoutineEditorFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/editor/RoutineEditorFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.navArgs
 import com.lateinit.rightweight.R
 import com.lateinit.rightweight.data.ExercisePartType
 import com.lateinit.rightweight.databinding.FragmentRoutineEditorBinding
@@ -21,7 +20,6 @@ class RoutineEditorFragment : Fragment() {
     private val binding
         get() = checkNotNull(_binding) { "binding was accessed outside of view lifecycle" }
 
-    private val args: RoutineEditorFragmentArgs by navArgs()
     private val viewModel: RoutineEditorViewModel by viewModels()
 
     private lateinit var routineDayAdapter: RoutineDayAdapter
@@ -37,7 +35,6 @@ class RoutineEditorFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel.init(args.routineId)
         setBinding()
         setRoutineDayAdapter()
         setRoutineDaysObserve()

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/editor/RoutineEditorViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/editor/RoutineEditorViewModel.kt
@@ -3,6 +3,7 @@ package com.lateinit.rightweight.ui.routine.editor
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
@@ -26,10 +27,11 @@ import javax.inject.Inject
 
 @HiltViewModel
 class RoutineEditorViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val routineRepository: RoutineRepository
 ) : ViewModel() {
 
-    private lateinit var routineId: String
+    private var routineId: String
 
     val routineTitle = MutableLiveData<String>()
     val routineDescription = MutableLiveData<String>()
@@ -62,12 +64,13 @@ class RoutineEditorViewModel @Inject constructor(
     }
     val dayExercises: LiveData<List<ExerciseUiModel>> = _dayExercises
 
-    fun init(routineId: String) {
+    init {
+        this.routineId = savedStateHandle.get<String>("routineId") ?: DEFAULT_ROUTINE_ID
+
         if (routineId.isEmpty()) {
             this.routineId = createUUID()
             addDay()
         } else {
-            this.routineId = routineId
             getRoutine(routineId)
         }
     }
@@ -288,5 +291,6 @@ class RoutineEditorViewModel @Inject constructor(
 
     companion object {
         private const val DEFAULT_EXERCISE_TITLE = ""
+        private const val DEFAULT_ROUTINE_ID = ""
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/editor/RoutineEditorViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/editor/RoutineEditorViewModel.kt
@@ -33,10 +33,11 @@ class RoutineEditorViewModel @Inject constructor(
 
     val routineTitle = MutableLiveData<String>()
     val routineDescription = MutableLiveData<String>()
-    val routineOrder = MutableLiveData<Int>()
+    private val routineOrder = MutableLiveData<Int>()
 
-    private val currentDayPosition = MutableLiveData<Int>()
+    private val currentDayPosition = MutableLiveData<Int?>()
     private val currentDay = currentDayPosition.map {
+        it ?: return@map null
         _days.value?.get(it)
     }
 
@@ -81,7 +82,7 @@ class RoutineEditorViewModel @Inject constructor(
 
     fun removeDay() {
         val days = _days.value ?: return
-        val dayPosition = currentDay.value?.order ?: return
+        val dayPosition = currentDayPosition.value ?: return
 
         days.removeAt(dayPosition).also { day ->
             dayToExercise.value?.remove(day.dayId)
@@ -97,7 +98,7 @@ class RoutineEditorViewModel @Inject constructor(
             dayPosition == reorderedDays.size -> reorderedDays.lastIndex
             else -> dayPosition
         }.also {
-            it ?: return
+            it ?: return@also
             reorderedDays[it] = reorderedDays[it].copy(selected = true)
         }
         _days.value = reorderedDays
@@ -187,7 +188,6 @@ class RoutineEditorViewModel @Inject constructor(
             } else {
                 routineOrder
             }
-
 
             if (title == null || title.isEmpty()) return@launch
             if (description == null || description.isEmpty()) return@launch


### PR DESCRIPTION
- close #88 

## 동작 화면

[untitled.webm](https://user-images.githubusercontent.com/64251968/204767572-e1f24525-7cc1-45c6-9c70-75264d585aba.webm)

## 작업 내용

- 화면 전환 시 day가 계속 추가되는 버그 수정
- day 한번 이상 삭제 시 꺼지는 버그 수정