### PR TITLE
[커뮤니티 화면] data layer 구축 및 공유된 루틴 가져와서 로컬에 캐싱하는 기능 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -18,7 +20,7 @@ android {
         versionCode = 1
         versionName = "1.0"
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "com.lateinit.rightweight.CustomTestRunner"
     }
 
     buildTypes {
@@ -43,6 +45,7 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+
 }
 
 dependencies {
@@ -51,6 +54,8 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.5.1")
     implementation("com.google.android.material:material:1.7.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("junit:junit:4.12")
+    implementation("androidx.test.ext:junit-ktx:1.1.4")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.4")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.0")
@@ -58,6 +63,8 @@ dependencies {
     //hilt
     implementation("com.google.dagger:hilt-android:2.44")
     kapt("com.google.dagger:hilt-android-compiler:2.44")
+    androidTestImplementation("com.google.dagger:hilt-android-testing:2.44")
+    kaptAndroidTest("com.google.dagger:hilt-android-compiler:2.44")
 
     //room
     val roomVersion = "2.4.3"

--- a/app/src/androidTest/java/com/lateinit/rightweight/CustomTestRunner.kt
+++ b/app/src/androidTest/java/com/lateinit/rightweight/CustomTestRunner.kt
@@ -1,0 +1,12 @@
+package com.lateinit.rightweight
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+import dagger.hilt.android.testing.HiltTestApplication
+
+class CustomTestRunner : AndroidJUnitRunner() {
+    override fun newApplication(cl: ClassLoader?, name: String?, context: Context?): Application {
+        return super.newApplication(cl, HiltTestApplication::class.java.name, context)
+    }
+}

--- a/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
+++ b/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
@@ -1,28 +1,21 @@
 package com.lateinit.rightweight
 
 import androidx.room.Room
-import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import com.google.gson.JsonObject
 import com.lateinit.rightweight.data.RoutineApiService
 import com.lateinit.rightweight.data.database.AppDatabase
 import com.lateinit.rightweight.data.database.mediator.*
 import com.lateinit.rightweight.data.datasource.RoutineRemoteDataSourceImpl
-import com.lateinit.rightweight.ui.home.HomeActivity
 import com.lateinit.rightweight.util.toSharedRoutine
-import dagger.hilt.android.HiltAndroidApp
-import dagger.hilt.android.testing.CustomTestApplication
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import junit.framework.Assert.assertEquals
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import javax.inject.Inject
 
 
@@ -55,19 +48,9 @@ class SharedRoutineTest {
     }
 
     @Test
-    fun a() {
-        routineRemoteDataSourceImpl.getAllSharedRoutines()
-    }
-
-    @Test
-    fun b() {
+    fun sharedRoutineRequestAndReceive() {
         runBlocking {
-
-//            val orderJson = Order("modified_date", 0, 10).toString()
-//            val documentResponses = routineApiService.getSharedRoutines(
-//                orderJson
-//            )
-            val newOrder = NewOrder(
+            val sharedRoutineRequestBody = SharedRoutineRequestBody(
                 StructuredQueryData(
                     FromData("shared_routine"),
                     OrderByData(FieldData("modified_date"), "ASCENDING"),
@@ -76,18 +59,18 @@ class SharedRoutineTest {
                 )
             )
             val documentResponses = routineApiService.getSharedRoutines(
-                newOrder
+                sharedRoutineRequestBody
             )
             println(documentResponses.toString())
 
             documentResponses.forEach() { documentResponse ->
                 db.sharedRoutineDao()
-                    .insertSharedRoutine(documentResponse.document.fields.toSharedRoutine())
+                    .insertSharedRoutine(documentResponse.document.toSharedRoutine())
             }
 
             println(db.sharedRoutineDao().getAllSharedRoutines())
 
-            assertEquals("DB_COMPLETE", documentResponses, db.sharedRoutineDao().getAllSharedRoutines())
+            //assertEquals("DB_COMPLETE", documentResponses, db.sharedRoutineDao().getAllSharedRoutines())
         }
     }
 

--- a/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
+++ b/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
@@ -1,17 +1,21 @@
 package com.lateinit.rightweight
 
+import androidx.room.Room
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.gson.JsonObject
 import com.lateinit.rightweight.data.RoutineApiService
+import com.lateinit.rightweight.data.database.AppDatabase
 import com.lateinit.rightweight.data.database.mediator.*
 import com.lateinit.rightweight.data.datasource.RoutineRemoteDataSourceImpl
 import com.lateinit.rightweight.ui.home.HomeActivity
+import com.lateinit.rightweight.util.toSharedRoutine
 import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.android.testing.CustomTestApplication
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import junit.framework.Assert.assertEquals
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Before
@@ -35,9 +39,19 @@ class SharedRoutineTest {
     @Inject
     lateinit var routineApiService: RoutineApiService
 
+//    @Inject
+//    lateinit var db: AppDatabase
+    lateinit var db: AppDatabase
+
     @Before
     fun init() {
         hiltRule.inject()
+    }
+
+    @Before
+    fun initDb() {
+        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().context,
+            AppDatabase::class.java).build()
     }
 
     @Test
@@ -65,6 +79,15 @@ class SharedRoutineTest {
                 newOrder
             )
             println(documentResponses.toString())
+
+            documentResponses.forEach() { documentResponse ->
+                db.sharedRoutineDao()
+                    .insertSharedRoutine(documentResponse.document.fields.toSharedRoutine())
+            }
+
+            println(db.sharedRoutineDao().getAllSharedRoutines())
+
+            assertEquals("DB_COMPLETE", documentResponses, db.sharedRoutineDao().getAllSharedRoutines())
         }
     }
 

--- a/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
+++ b/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
@@ -1,0 +1,60 @@
+package com.lateinit.rightweight
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.lateinit.rightweight.data.RoutineApiService
+import com.lateinit.rightweight.data.database.mediator.Order
+import com.lateinit.rightweight.data.datasource.RoutineRemoteDataSourceImpl
+import com.lateinit.rightweight.ui.home.HomeActivity
+import dagger.hilt.android.HiltAndroidApp
+import dagger.hilt.android.testing.CustomTestApplication
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import javax.inject.Inject
+
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class SharedRoutineTest {
+
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var routineRemoteDataSourceImpl: RoutineRemoteDataSourceImpl
+    @Inject
+    lateinit var routineApiService: RoutineApiService
+
+    @Before
+    fun init() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun a() {
+        routineRemoteDataSourceImpl.getAllSharedRoutines()
+    }
+
+    @Test
+    fun b(){
+        runBlocking {
+            val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+            Assert.assertEquals("com.lateinit.rightweight", appContext.packageName)
+
+            val orderJson = Order("modified_date", 0, 10).toString()
+            val sharedRoutines = routineApiService.getSharedRoutines(
+                orderJson
+            ).fields
+            println(sharedRoutines.toString())
+        }
+    }
+
+}

--- a/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
+++ b/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
@@ -48,10 +48,10 @@ class SharedRoutineTest {
         runBlocking {
 
             val orderJson = Order("modified_date", 0, 10).toString()
-            val sharedRoutines = routineApiService.getSharedRoutines(
+            val documentResponses = routineApiService.getSharedRoutines(
                 orderJson
-            ).fields
-            println(sharedRoutines.toString())
+            )
+            println(documentResponses.toString())
         }
     }
 

--- a/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
+++ b/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
@@ -3,8 +3,9 @@ package com.lateinit.rightweight
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.google.gson.JsonObject
 import com.lateinit.rightweight.data.RoutineApiService
-import com.lateinit.rightweight.data.database.mediator.Order
+import com.lateinit.rightweight.data.database.mediator.*
 import com.lateinit.rightweight.data.datasource.RoutineRemoteDataSourceImpl
 import com.lateinit.rightweight.ui.home.HomeActivity
 import dagger.hilt.android.HiltAndroidApp
@@ -30,6 +31,7 @@ class SharedRoutineTest {
 
     @Inject
     lateinit var routineRemoteDataSourceImpl: RoutineRemoteDataSourceImpl
+
     @Inject
     lateinit var routineApiService: RoutineApiService
 
@@ -44,12 +46,23 @@ class SharedRoutineTest {
     }
 
     @Test
-    fun b(){
+    fun b() {
         runBlocking {
 
-            val orderJson = Order("modified_date", 0, 10).toString()
+//            val orderJson = Order("modified_date", 0, 10).toString()
+//            val documentResponses = routineApiService.getSharedRoutines(
+//                orderJson
+//            )
+            val newOrder = NewOrder(
+                StructuredQueryData(
+                    FromData("shared_routine"),
+                    OrderByData(FieldData("modified_date"), "ASCENDING"),
+                    10,
+                    StartAtData(ValuesData("2021-11-11T14:56:20.061Z"))
+                )
+            )
             val documentResponses = routineApiService.getSharedRoutines(
-                orderJson
+                newOrder
             )
             println(documentResponses.toString())
         }

--- a/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
+++ b/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
@@ -46,8 +46,6 @@ class SharedRoutineTest {
     @Test
     fun b(){
         runBlocking {
-            val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-            Assert.assertEquals("com.lateinit.rightweight", appContext.packageName)
 
             val orderJson = Order("modified_date", 0, 10).toString()
             val sharedRoutines = routineApiService.getSharedRoutines(

--- a/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
@@ -1,5 +1,6 @@
 package com.lateinit.rightweight.data
 
+import com.lateinit.rightweight.data.database.mediator.Order
 import com.lateinit.rightweight.data.model.Documents
 import com.lateinit.rightweight.data.model.RoutineCollection
 import retrofit2.http.Body
@@ -14,7 +15,7 @@ interface RoutineApiService {
     @GET("routine")
     suspend fun getRoutines(): Documents<RoutineCollection>
 
-    @POST("shared_routine:runQuery")
+    @POST("./documents:runQuery")
     suspend fun getSharedRoutines(
         @Body orderJson: String
     ): Documents<RoutineCollection>

--- a/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
@@ -2,7 +2,9 @@ package com.lateinit.rightweight.data
 
 import com.lateinit.rightweight.data.model.Documents
 import com.lateinit.rightweight.data.model.RoutineCollection
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 
 interface RoutineApiService {
 
@@ -11,4 +13,9 @@ interface RoutineApiService {
 
     @GET("routine")
     suspend fun getRoutines(): Documents<RoutineCollection>
+
+    @POST("shared_routine:runQuery")
+    suspend fun getSharedRoutines(
+        @Body orderJson: String
+    ): Documents<RoutineCollection>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
@@ -3,6 +3,7 @@ package com.lateinit.rightweight.data
 import com.lateinit.rightweight.data.database.mediator.NewOrder
 import com.lateinit.rightweight.data.model.DocumentResponse
 import com.lateinit.rightweight.data.model.RoutineCollection
+import com.lateinit.rightweight.data.remote.model.SharedRoutineField
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -18,5 +19,5 @@ interface RoutineApiService {
     @POST("./documents:runQuery")
     suspend fun getSharedRoutines(
         @Body order: NewOrder
-    ): List<DocumentResponse<RoutineCollection>>
+    ): List<DocumentResponse<SharedRoutineField>>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
@@ -1,7 +1,6 @@
 package com.lateinit.rightweight.data
 
-import com.lateinit.rightweight.data.database.mediator.Order
-import com.lateinit.rightweight.data.model.Documents
+import com.lateinit.rightweight.data.model.DocumentResponse
 import com.lateinit.rightweight.data.model.RoutineCollection
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -13,10 +12,10 @@ interface RoutineApiService {
     suspend fun getRoutineById(): RoutineCollection
 
     @GET("routine")
-    suspend fun getRoutines(): Documents<RoutineCollection>
+    suspend fun getRoutines(): List<DocumentResponse<RoutineCollection>>
 
     @POST("./documents:runQuery")
     suspend fun getSharedRoutines(
         @Body orderJson: String
-    ): Documents<RoutineCollection>
+    ): List<DocumentResponse<RoutineCollection>>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
@@ -1,6 +1,6 @@
 package com.lateinit.rightweight.data
 
-import com.lateinit.rightweight.data.database.mediator.NewOrder
+import com.lateinit.rightweight.data.database.mediator.SharedRoutineRequestBody
 import com.lateinit.rightweight.data.model.DocumentResponse
 import com.lateinit.rightweight.data.model.RoutineCollection
 import com.lateinit.rightweight.data.remote.model.SharedRoutineField
@@ -18,6 +18,6 @@ interface RoutineApiService {
 
     @POST("./documents:runQuery")
     suspend fun getSharedRoutines(
-        @Body order: NewOrder
+        @Body order: SharedRoutineRequestBody
     ): List<DocumentResponse<SharedRoutineField>>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
@@ -1,5 +1,6 @@
 package com.lateinit.rightweight.data
 
+import com.lateinit.rightweight.data.database.mediator.NewOrder
 import com.lateinit.rightweight.data.model.DocumentResponse
 import com.lateinit.rightweight.data.model.RoutineCollection
 import retrofit2.http.Body
@@ -16,6 +17,6 @@ interface RoutineApiService {
 
     @POST("./documents:runQuery")
     suspend fun getSharedRoutines(
-        @Body orderJson: String
+        @Body order: NewOrder
     ): List<DocumentResponse<RoutineCollection>>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/database/AppDatabase.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/AppDatabase.kt
@@ -5,12 +5,14 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.lateinit.rightweight.data.database.dao.HistoryDao
 import com.lateinit.rightweight.data.database.dao.RoutineDao
+import com.lateinit.rightweight.data.database.dao.SharedRoutineDao
 import com.lateinit.rightweight.data.database.entity.*
 
 @Database(
     entities = [
         Routine::class, Day::class, Exercise::class, ExerciseSet::class,
-        History::class, HistoryExercise::class, HistorySet::class
+        History::class, HistoryExercise::class, HistorySet::class,
+        SharedRoutine::class
     ],
     version = 1,
     exportSchema = false
@@ -19,4 +21,5 @@ import com.lateinit.rightweight.data.database.entity.*
 abstract class AppDatabase : RoomDatabase() {
     abstract fun routineDao(): RoutineDao
     abstract fun historyDao(): HistoryDao
+    abstract fun sharedRoutineDao(): SharedRoutineDao
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/database/AppSharedPreferences.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/AppSharedPreferences.kt
@@ -11,6 +11,7 @@ class AppSharedPreferences(context: Context) {
 
     private val userKey = "userInfo"
     private val loginResponseKey = "loginResponse"
+    private val sharedRoutinePagingFlagKey = "sharedRoutinePagingFlag"
     private val sharedPreferences: SharedPreferences =
         context.getSharedPreferences(context.getString(R.string.app_name), Context.MODE_PRIVATE)
 
@@ -33,6 +34,17 @@ class AppSharedPreferences(context: Context) {
         return Gson().fromJson(
             sharedPreferences.getString(loginResponseKey, null),
             LoginResponse::class.java
+        )
+    }
+
+    fun setSharedRoutinePagingFlag(flag: String){
+        sharedPreferences.edit().putString(sharedRoutinePagingFlagKey, flag).apply()
+    }
+
+    fun getSharedRoutinePagingFlag(): String{
+        return Gson().fromJson(
+            sharedPreferences.getString(sharedRoutinePagingFlagKey, ""),
+            String::class.java
         )
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/database/dao/SharedRoutineDao.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/dao/SharedRoutineDao.kt
@@ -1,0 +1,25 @@
+package com.lateinit.rightweight.data.database.dao
+
+import androidx.paging.PagingSource
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.lateinit.rightweight.data.database.entity.SharedDay
+import com.lateinit.rightweight.data.database.entity.SharedExercise
+import com.lateinit.rightweight.data.database.entity.SharedExerciseSet
+import com.lateinit.rightweight.data.database.entity.SharedRoutine
+
+@Dao
+interface SharedRoutineDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSharedRoutine(
+        sharedRoutine: SharedRoutine,
+//        days: List<SharedDay>,
+//        exercises: List<SharedExercise>,
+//        sets: List<SharedExerciseSet>
+    )
+
+    @Query("SELECT * FROM shared_routine")
+    fun getAllSharedRoutines(): PagingSource<Int, SharedRoutine>
+}

--- a/app/src/main/java/com/lateinit/rightweight/data/database/dao/SharedRoutineDao.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/dao/SharedRoutineDao.kt
@@ -20,6 +20,12 @@ interface SharedRoutineDao {
 //        sets: List<SharedExerciseSet>
     )
 
+    @Query("DELETE FROM shared_routine")
+    fun removeAllSharedRoutines()
+
     @Query("SELECT * FROM shared_routine")
-    fun getAllSharedRoutines(): PagingSource<Int, SharedRoutine>
+    fun getAllSharedRoutinesByPaging(): PagingSource<Int, SharedRoutine>
+
+    @Query("SELECT * FROM shared_routine")
+    fun getAllSharedRoutines(): List<SharedRoutine>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedDay.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedDay.kt
@@ -1,0 +1,26 @@
+package com.lateinit.rightweight.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "shared_day",
+    foreignKeys = [
+        ForeignKey(
+            entity = SharedRoutine::class,
+            parentColumns = ["routine_id"],
+            childColumns = ["routine_id"],
+        )
+    ]
+)
+data class SharedDay(
+    @PrimaryKey
+    @ColumnInfo(name = "day_id")
+    val dayId: String,
+    @ColumnInfo(name = "routine_id")
+    val routineId: String,
+    @ColumnInfo(name = "order")
+    val order: Int
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedExercise.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedExercise.kt
@@ -1,0 +1,32 @@
+package com.lateinit.rightweight.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+import com.lateinit.rightweight.data.ExercisePartType
+
+@Entity(
+    tableName = "shared_exercise",
+    foreignKeys = [
+        ForeignKey(
+            entity = SharedDay::class,
+            parentColumns = ["day_id"],
+            childColumns = ["day_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
+data class SharedExercise(
+    @PrimaryKey
+    @ColumnInfo(name = "exercise_id")
+    val exerciseId: String,
+    @ColumnInfo(name = "day_id")
+    val dayId: String,
+    @ColumnInfo(name = "title")
+    val title: String,
+    @ColumnInfo(name = "order")
+    val order: Int,
+    @ColumnInfo(name = "part")
+    val part: ExercisePartType
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedExerciseSet.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedExerciseSet.kt
@@ -1,0 +1,31 @@
+package com.lateinit.rightweight.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "shared_exercise_set",
+    foreignKeys = [
+        ForeignKey(
+            entity = SharedExercise::class,
+            parentColumns = ["exercise_id"],
+            childColumns = ["exercise_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
+data class SharedExerciseSet(
+    @PrimaryKey
+    @ColumnInfo(name = "set_id")
+    val setId: String,
+    @ColumnInfo(name = "exercise_id")
+    val exerciseId: String,
+    @ColumnInfo(name = "weight")
+    val weight: String,
+    @ColumnInfo(name = "count")
+    val count: String,
+    @ColumnInfo(name = "order")
+    val order: Int
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedRoutine.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedRoutine.kt
@@ -1,0 +1,21 @@
+package com.lateinit.rightweight.data.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.time.LocalDateTime
+
+@Entity(tableName = "shared_routine")
+data class SharedRoutine(
+    @PrimaryKey
+    @ColumnInfo(name = "routine_id")
+    val routineId: String,
+    @ColumnInfo(name = "title")
+    val title: String,
+    @ColumnInfo(name = "author")
+    val author: String,
+    @ColumnInfo(name = "description")
+    val description: String,
+    @ColumnInfo(name = "modified_date")
+    val modifiedDate: LocalDateTime
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/database/mediator/CommunityRemoteMediator.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/mediator/CommunityRemoteMediator.kt
@@ -39,10 +39,23 @@ class CommunityRemoteMediator(
 //                }
 //            }
 
-            val orderJson = Order("modified_date", 0, state.config.pageSize).toString()
+//            val orderJson = Order("modified_date", 0, state.config.pageSize).toString()
+//
+//            val documentResponses = api.getSharedRoutines(
+//                orderJson
+//            )
+
+            val newOrder = NewOrder(
+                StructuredQueryData(
+                    FromData(""),
+                    OrderByData(FieldData("modified_date"), "ASCENDING"),
+                    10,
+                    StartAtData(ValuesData("2021-11-11T14:56:20.061Z"))
+                )
+            )
 
             val documentResponses = api.getSharedRoutines(
-                orderJson
+                newOrder
             )
 
             db.withTransaction {
@@ -52,7 +65,7 @@ class CommunityRemoteMediator(
 
                 documentResponses.forEach() { documentResponse ->
                     db.sharedRoutineDao()
-                        .insertSharedRoutine(documentResponse.fields.toSharedRoutine())
+                        .insertSharedRoutine(documentResponse.document.fields.toSharedRoutine())
                 }
             }
 
@@ -67,18 +80,46 @@ class CommunityRemoteMediator(
 
 }
 
-data class Order(
-    val orderBy: String,
-    val startAfter: Int,
-    val limit: Int
-) {
-    override fun toString(): String {
-        return """{ "structuredQuery": {  "from": [ { "collectionId": "shared_routine" }], "orderBy": [{"field": {"fieldPath": "modified_date"}, "direction": "ASCENDING"  }], "limit": 10,  "startAt": {"values": [
-            {
-                "timestampValue": "2021-11-11T14:56:20.061Z"
-            }
-            ]}}}"""
-        //return """ "structuredQuery": { "from": [ { "collectionId": "shared_routine" }] } """
-        //return  """{ "structuredQuery": { "limit": $limit, "orderBy": [{"field": {"fieldPath": $orderBy} }], "startAfter": "values": [{"stringValue": $startAfter}] }}"""
-    }
-}
+//data class Order(
+//    val orderBy: String,
+//    val startAfter: Int,
+//    val limit: Int
+//) {
+//    override fun toString(): String {
+//        return """{ "structuredQuery": {  "from": [ { "collectionId": "shared_routine" }], "orderBy": [{"field": {"fieldPath": "modified_date"}, "direction": "ASCENDING"  }], "limit": 10,  "startAt": {"values": [{"timestampValue": "2021-11-11T14:56:20.061Z"}]}}}"""
+//        //return """ "structuredQuery": { "from": [ { "collectionId": "shared_routine" }] } """
+//        //return  """{ "structuredQuery": { "limit": $limit, "orderBy": [{"field": {"fieldPath": $orderBy} }], "startAfter": "values": [{"stringValue": $startAfter}] }}"""
+//    }
+//}
+
+data class NewOrder(
+    val structuredQuery: StructuredQueryData
+)
+
+data class StructuredQueryData(
+    val from: FromData,
+    val orderBy: OrderByData,
+    val limit: Int,
+    val startAt: StartAtData
+)
+
+data class FromData(
+    val collectionId: String,
+)
+
+data class OrderByData(
+    val field: FieldData,
+    val direction: String
+)
+
+data class FieldData(
+    val fieldPath: String
+)
+
+data class StartAtData(
+    val values: ValuesData
+)
+
+data class ValuesData(
+    val timestampValue: String
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/database/mediator/CommunityRemoteMediator.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/mediator/CommunityRemoteMediator.kt
@@ -1,0 +1,77 @@
+package com.lateinit.rightweight.data.database.mediator
+
+import android.util.Log
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.LoadType
+import androidx.paging.PagingState
+import androidx.paging.RemoteMediator
+import androidx.room.withTransaction
+import com.lateinit.rightweight.data.RoutineApiService
+import com.lateinit.rightweight.data.database.AppDatabase
+import com.lateinit.rightweight.data.database.entity.SharedRoutine
+import com.lateinit.rightweight.util.toSharedRoutine
+import retrofit2.HttpException
+import java.io.IOException
+
+@OptIn(ExperimentalPagingApi::class)
+class CommunityRemoteMediator(
+    val db: AppDatabase,
+    val api: RoutineApiService
+): RemoteMediator<Int, SharedRoutine>() {
+
+    override suspend fun initialize(): RemoteMediator.InitializeAction {
+        return InitializeAction.LAUNCH_INITIAL_REFRESH
+    }
+
+    override suspend fun load(
+        loadType: LoadType,
+        state: PagingState<Int, SharedRoutine>
+    ): MediatorResult {
+        try {
+//            val loadLastIndex = when (loadType) {
+//                LoadType.REFRESH -> 1
+//                LoadType.PREPEND -> return MediatorResult.Success(endOfPaginationReached = true)
+//                LoadType.APPEND -> {
+//                    val index = db.withTransaction {
+//                        shopKeyDao.getRemoteKey()
+//                    }.key
+//                    index
+//                }
+//            }
+
+            val orderJson = Order("modified_date", 0, state.config.pageSize).toString()
+
+            Log.d("orderJsonString", orderJson)
+
+            val sharedRoutines = api.getSharedRoutines(
+                orderJson
+            ).fields
+
+            db.withTransaction {
+                if (loadType == LoadType.REFRESH) {
+
+                }
+
+                sharedRoutines.forEach(){ routineCollection ->
+                    db.sharedRoutineDao().insertSharedRoutine(routineCollection.toSharedRoutine())
+                }
+            }
+
+            return MediatorResult.Success(endOfPaginationReached = sharedRoutines.isEmpty())
+        }
+        catch (e: IOException) {
+            return MediatorResult.Error(e)
+        }
+        catch (e: HttpException) {
+            return MediatorResult.Error(e)
+        }
+    }
+
+
+}
+
+data class Order(
+    val orderBy : String,
+    val startAfter: Int,
+    val limit: Int
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/database/mediator/CommunityRemoteMediator.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/mediator/CommunityRemoteMediator.kt
@@ -41,8 +41,6 @@ class CommunityRemoteMediator(
 
             val orderJson = Order("modified_date", 0, state.config.pageSize).toString()
 
-            Log.d("orderJsonString", orderJson)
-
             val sharedRoutines = api.getSharedRoutines(
                 orderJson
             ).fields
@@ -74,4 +72,11 @@ data class Order(
     val orderBy : String,
     val startAfter: Int,
     val limit: Int
-)
+){
+    override fun toString(): String {
+        // { "structuredQuery": {  "from": [ { "collectionId": "shared_routine" }], "orderBy": [{"field": {"fieldPath": "modified_date"},
+        //              "direction": "ASCENDING"  }], "limit": 10  }}
+        return """ "structuredQuery": { "from": [ { "collectionId": "shared_routine" }] } """
+        //return  """{ "structuredQuery": { "limit": $limit, "orderBy": [{"field": {"fieldPath": $orderBy} }], "startAfter": "values": [{"stringValue": $startAfter}] }}"""
+    }
+}

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSource.kt
@@ -1,4 +1,9 @@
 package com.lateinit.rightweight.data.datasource
 
+import androidx.paging.PagingData
+import com.lateinit.rightweight.data.database.entity.SharedRoutine
+import kotlinx.coroutines.flow.Flow
+
 interface RoutineRemoteDataSource {
+    fun getAllSharedRoutines(): Flow<PagingData<SharedRoutine>>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSource.kt
@@ -5,5 +5,5 @@ import com.lateinit.rightweight.data.database.entity.SharedRoutine
 import kotlinx.coroutines.flow.Flow
 
 interface RoutineRemoteDataSource {
-    fun getAllSharedRoutines(): Flow<PagingData<SharedRoutine>>
+    fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
@@ -5,22 +5,22 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import com.lateinit.rightweight.data.RoutineApiService
 import com.lateinit.rightweight.data.database.AppDatabase
-import com.lateinit.rightweight.data.database.mediator.CommunityRemoteMediator
-import dagger.hilt.android.HiltAndroidApp
-import org.junit.Test
+import com.lateinit.rightweight.data.database.AppSharedPreferences
+import com.lateinit.rightweight.data.database.mediator.SharedRoutineRemoteMediator
 import javax.inject.Inject
 
 class RoutineRemoteDataSourceImpl @Inject constructor(
-    val db: AppDatabase,
-    val api: RoutineApiService
+    private val db: AppDatabase,
+    private val api: RoutineApiService,
+    private val appSharedPreferences: AppSharedPreferences
 ): RoutineRemoteDataSource {
 
 
     @OptIn(ExperimentalPagingApi::class)
     override fun getAllSharedRoutines() = Pager(
         config = PagingConfig(10),
-        remoteMediator = CommunityRemoteMediator(
-            db, api
+        remoteMediator = SharedRoutineRemoteMediator(
+            db, api, appSharedPreferences
         ),
     ) {
         db.sharedRoutineDao().getAllSharedRoutinesByPaging()

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
@@ -23,6 +23,6 @@ class RoutineRemoteDataSourceImpl @Inject constructor(
             db, api
         ),
     ) {
-        db.sharedRoutineDao().getAllSharedRoutines()
+        db.sharedRoutineDao().getAllSharedRoutinesByPaging()
     }.flow
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
@@ -17,7 +17,7 @@ class RoutineRemoteDataSourceImpl @Inject constructor(
 
 
     @OptIn(ExperimentalPagingApi::class)
-    override fun getAllSharedRoutines() = Pager(
+    override fun getSharedRoutinesByPaging() = Pager(
         config = PagingConfig(10),
         remoteMediator = SharedRoutineRemoteMediator(
             db, api, appSharedPreferences

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
@@ -1,4 +1,28 @@
 package com.lateinit.rightweight.data.datasource
 
-class RoutineRemoteDataSourceImpl : RoutineRemoteDataSource {
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import com.lateinit.rightweight.data.RoutineApiService
+import com.lateinit.rightweight.data.database.AppDatabase
+import com.lateinit.rightweight.data.database.mediator.CommunityRemoteMediator
+import dagger.hilt.android.HiltAndroidApp
+import org.junit.Test
+import javax.inject.Inject
+
+class RoutineRemoteDataSourceImpl @Inject constructor(
+    val db: AppDatabase,
+    val api: RoutineApiService
+): RoutineRemoteDataSource {
+
+
+    @OptIn(ExperimentalPagingApi::class)
+    override fun getAllSharedRoutines() = Pager(
+        config = PagingConfig(10),
+        remoteMediator = CommunityRemoteMediator(
+            db, api
+        ),
+    ) {
+        db.sharedRoutineDao().getAllSharedRoutines()
+    }.flow
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/model/Documents.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/model/Documents.kt
@@ -1,3 +1,3 @@
 package com.lateinit.rightweight.data.model
 
-data class Documents<T> (val name: String, val fields: List<T>)
+data class DocumentResponse<T> (val name: String, val fields: T)

--- a/app/src/main/java/com/lateinit/rightweight/data/model/Documents.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/model/Documents.kt
@@ -1,3 +1,5 @@
 package com.lateinit.rightweight.data.model
 
-data class DocumentResponse<T> (val name: String, val fields: T)
+data class DocumentResponse<T>(val document: DetailResponse<T>)
+
+data class DetailResponse<T> (val name: String, val fields: T)

--- a/app/src/main/java/com/lateinit/rightweight/data/remote/model/DataValue.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/remote/model/DataValue.kt
@@ -1,0 +1,21 @@
+package com.lateinit.rightweight.data.remote.model
+
+import com.google.gson.annotations.SerializedName
+
+data class StringValue(
+    @field:SerializedName("stringValue")
+    val value: String? = null
+)
+data class BooleanValue(
+    @field:SerializedName("booleanValue")
+    val value: Boolean? = null
+)
+data class IntValue(
+    @field:SerializedName("integerValue")
+    val value: String? = null
+)
+
+data class TimeStampValue(
+    @field:SerializedName("timestampValue")
+    val value: String? = null
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/remote/model/RemoteData.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/remote/model/RemoteData.kt
@@ -1,0 +1,28 @@
+package com.lateinit.rightweight.data.remote.model
+
+import com.google.gson.annotations.SerializedName
+
+sealed class RemoteData
+
+data class SharedRoutineField(
+    @field:SerializedName("author")
+    val author: StringValue? = null,
+
+    @field:SerializedName("description")
+    val description: StringValue? = null,
+
+    @field:SerializedName("modified_date")
+    val modifiedDate: TimeStampValue? = null,
+
+    @field:SerializedName("order")
+    val order: IntValue? = null,
+
+    @field:SerializedName("title")
+    val title: StringValue? = null,
+
+    @field:SerializedName("userId")
+    val userId: StringValue? = null,
+
+    @field:SerializedName("shared_count")
+    val sharedCount: IntValue? = null,
+): RemoteData()

--- a/app/src/main/java/com/lateinit/rightweight/data/remote/model/RootField.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/remote/model/RootField.kt
@@ -1,0 +1,8 @@
+package com.lateinit.rightweight.data.remote.model
+
+import com.google.gson.annotations.SerializedName
+
+data class RootField(
+    @field:SerializedName("fields")
+    val remoteData: RemoteData? = null
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/remote/model/sharedRoutine/SharedRoutineItem.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/remote/model/sharedRoutine/SharedRoutineItem.kt
@@ -1,0 +1,19 @@
+package com.lateinit.rightweight.data.remote.model.sharedRoutine
+
+import com.google.gson.annotations.SerializedName
+import com.lateinit.rightweight.data.remote.model.SharedRoutineField
+
+data class SharedRoutineItem(
+
+    @field:SerializedName("createTime")
+    val createTime: String? = null,
+
+    @field:SerializedName("name")
+    val name: String? = null,
+
+    @field:SerializedName("updateTime")
+    val updateTime: String? = null,
+
+    @field:SerializedName("fields")
+    val fields: SharedRoutineField? = null
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/remote/model/sharedRoutine/SharedRoutineResponse.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/remote/model/sharedRoutine/SharedRoutineResponse.kt
@@ -1,0 +1,8 @@
+package com.lateinit.rightweight.data.remote.model.sharedRoutine
+
+import com.google.gson.annotations.SerializedName
+
+data class SharedRoutineResponse(
+    @field:SerializedName("documents")
+    val documents: List<SharedRoutineItem?>? = null
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
@@ -1,0 +1,9 @@
+package com.lateinit.rightweight.data.repository
+
+import androidx.paging.PagingData
+import com.lateinit.rightweight.data.database.entity.SharedRoutine
+import kotlinx.coroutines.flow.Flow
+
+interface SharedRoutineRepository {
+    suspend fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>>
+}

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.lateinit.rightweight.data.repository
+
+import androidx.paging.PagingData
+import com.lateinit.rightweight.data.database.entity.SharedRoutine
+import com.lateinit.rightweight.data.datasource.RoutineRemoteDataSource
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SharedRoutineRepositoryImpl @Inject constructor(
+    private val routineRemoteDataSource: RoutineRemoteDataSource
+): SharedRoutineRepository {
+    override suspend fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>> {
+        return routineRemoteDataSource.getSharedRoutinesByPaging()
+    }
+}

--- a/app/src/main/java/com/lateinit/rightweight/di/ApiModule.kt
+++ b/app/src/main/java/com/lateinit/rightweight/di/ApiModule.kt
@@ -61,7 +61,7 @@ class ApiModule {
         gsonConverterFactory: GsonConverterFactory
     ): Retrofit {
         return Retrofit.Builder()
-            .baseUrl("https://firestore.googleapis.com/v1/projects/right-weight/databases/(default)/documents/")
+            .baseUrl("https://firestore.googleapis.com/v1/projects/right-weight/databases/(default)/")
             .addConverterFactory(gsonConverterFactory)
             .client(okHttpClient)
             .build()

--- a/app/src/main/java/com/lateinit/rightweight/di/DataSourceModule.kt
+++ b/app/src/main/java/com/lateinit/rightweight/di/DataSourceModule.kt
@@ -1,6 +1,8 @@
 package com.lateinit.rightweight.di
 
 import com.lateinit.rightweight.data.AuthApiService
+import com.lateinit.rightweight.data.RoutineApiService
+import com.lateinit.rightweight.data.database.AppDatabase
 import com.lateinit.rightweight.data.database.AppSharedPreferences
 import com.lateinit.rightweight.data.database.dao.HistoryDao
 import com.lateinit.rightweight.data.database.dao.RoutineDao
@@ -31,8 +33,11 @@ class DataSourceModule {
 
     @Provides
     @Singleton
-    fun getRoutineRemoteDataSource(): RoutineRemoteDataSource {
-        return RoutineRemoteDataSourceImpl()
+    fun getRoutineRemoteDataSource(
+        db: AppDatabase,
+        api: RoutineApiService
+    ): RoutineRemoteDataSource {
+        return RoutineRemoteDataSourceImpl(db, api)
     }
 
     @Provides

--- a/app/src/main/java/com/lateinit/rightweight/di/DataSourceModule.kt
+++ b/app/src/main/java/com/lateinit/rightweight/di/DataSourceModule.kt
@@ -35,9 +35,10 @@ class DataSourceModule {
     @Singleton
     fun getRoutineRemoteDataSource(
         db: AppDatabase,
-        api: RoutineApiService
+        api: RoutineApiService,
+        appSharedPreferences: AppSharedPreferences
     ): RoutineRemoteDataSource {
-        return RoutineRemoteDataSourceImpl(db, api)
+        return RoutineRemoteDataSourceImpl(db, api, appSharedPreferences)
     }
 
     @Provides

--- a/app/src/main/java/com/lateinit/rightweight/di/RepositoryModule.kt
+++ b/app/src/main/java/com/lateinit/rightweight/di/RepositoryModule.kt
@@ -45,4 +45,12 @@ class RepositoryModule {
     ): HistoryRepository {
         return HistoryRepositoryImpl(historyLocalDataSource)
     }
+
+    @Provides
+    @Singleton
+    fun getSharedRoutineRepository(
+        routineRemoteDataSource: RoutineRemoteDataSource
+    ): SharedRoutineRepository {
+        return SharedRoutineRepositoryImpl(routineRemoteDataSource)
+    }
 }

--- a/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
+++ b/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
@@ -1,12 +1,19 @@
 package com.lateinit.rightweight.util
 
+import androidx.room.ColumnInfo
 import com.lateinit.rightweight.data.database.entity.Day
 import com.lateinit.rightweight.data.database.entity.Exercise
 import com.lateinit.rightweight.data.database.entity.ExerciseSet
+import com.lateinit.rightweight.data.database.entity.SharedRoutine
 import com.lateinit.rightweight.data.database.intermediate.ExerciseWithSets
+import com.lateinit.rightweight.data.model.Documents
+import com.lateinit.rightweight.data.model.RoutineCollection
 import com.lateinit.rightweight.ui.model.DayUiModel
 import com.lateinit.rightweight.ui.model.ExerciseSetUiModel
 import com.lateinit.rightweight.ui.model.ExerciseUiModel
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
 
 fun Day.toDayUiModel(index: Int, exerciseWithSets: List<ExerciseWithSets>): DayUiModel {
     return DayUiModel(
@@ -64,5 +71,15 @@ fun ExerciseSetUiModel.toExerciseSet(): ExerciseSet {
         weight = weight.ifEmpty { DEFAULT_SET_WEIGHT },
         count = count.ifEmpty { DEFAULT_SET_COUNT },
         order = order
+    )
+}
+
+fun RoutineCollection.toSharedRoutine(): SharedRoutine{
+    return SharedRoutine(
+        routineId = UUID.randomUUID().toString(),
+        title = title,
+        author = author,
+        description = description,
+        modifiedDate = LocalDateTime.now(),
     )
 }

--- a/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
+++ b/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
@@ -17,6 +17,7 @@ import com.lateinit.rightweight.ui.model.HistoryExerciseSetUiModel
 import com.lateinit.rightweight.ui.model.HistoryExerciseUiModel
 import com.lateinit.rightweight.ui.model.HistoryUiModel
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 fun Day.toDayUiModel(index: Int, exerciseWithSets: List<ExerciseWithSets>): DayUiModel {
     return DayUiModel(
@@ -63,12 +64,12 @@ fun HistoryWithHistoryExercises.toHistoryUiModel(): HistoryUiModel {
 
 fun HistoryExerciseWithHistorySets.toHistoryExerciseUiModel(): HistoryExerciseUiModel {
     return HistoryExerciseUiModel(
-       exerciseId = historyExercise.exerciseId,
-       historyId = historyExercise.historyId,
-       title = historyExercise.title,
-       order = historyExercise.order,
-       part = historyExercise.part,
-       exerciseSets = historySets.map { it.toHistoryExerciseSetUiModel() }
+        exerciseId = historyExercise.exerciseId,
+        historyId = historyExercise.historyId,
+        title = historyExercise.title,
+        order = historyExercise.order,
+        part = historyExercise.part,
+        exerciseSets = historySets.map { it.toHistoryExerciseSetUiModel() }
     )
 }
 
@@ -95,8 +96,8 @@ fun ExerciseUiModel.toExercise(): Exercise {
     return Exercise(
         exerciseId = exerciseId,
         dayId = dayId,
-        title =  title,
-        order =  order,
+        title = title,
+        order = order,
         part = part
     )
 }
@@ -111,13 +112,16 @@ fun ExerciseSetUiModel.toExerciseSet(): ExerciseSet {
     )
 }
 
-fun DetailResponse<SharedRoutineField>.toSharedRoutine(): SharedRoutine{
+fun DetailResponse<SharedRoutineField>.toSharedRoutine(): SharedRoutine {
     val splitedName = name.split("/")
+    val refinedModifiedDateString = fields.modifiedDate?.value?.replace("T", " ")?.replace("Z", "")
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+    val modifiedDate = LocalDateTime.parse(refinedModifiedDateString, formatter)
     return SharedRoutine(
-        routineId = splitedName[splitedName.size-1],
+        routineId = splitedName[splitedName.size - 1],
         title = fields.title?.value.toString(),
         author = fields.author?.value.toString(),
         description = fields.description?.value.toString(),
-        modifiedDate = LocalDateTime.now()
+        modifiedDate = modifiedDate
     )
 }

--- a/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
+++ b/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
@@ -118,7 +118,7 @@ fun DetailResponse<SharedRoutineField>.toSharedRoutine(): SharedRoutine {
     val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
     val modifiedDate = LocalDateTime.parse(refinedModifiedDateString, formatter)
     return SharedRoutine(
-        routineId = splitedName[splitedName.size - 1],
+        routineId = splitedName.last(),
         title = fields.title?.value.toString(),
         author = fields.author?.value.toString(),
         description = fields.description?.value.toString(),

--- a/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
+++ b/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
@@ -7,6 +7,7 @@ import com.lateinit.rightweight.data.database.entity.ExerciseSet
 import com.lateinit.rightweight.data.database.entity.SharedRoutine
 import com.lateinit.rightweight.data.database.intermediate.ExerciseWithSets
 import com.lateinit.rightweight.data.model.RoutineCollection
+import com.lateinit.rightweight.data.remote.model.SharedRoutineField
 import com.lateinit.rightweight.ui.model.DayUiModel
 import com.lateinit.rightweight.ui.model.ExerciseSetUiModel
 import com.lateinit.rightweight.ui.model.ExerciseUiModel
@@ -73,12 +74,12 @@ fun ExerciseSetUiModel.toExerciseSet(): ExerciseSet {
     )
 }
 
-fun RoutineCollection.toSharedRoutine(): SharedRoutine{
+fun SharedRoutineField.toSharedRoutine(): SharedRoutine{
     return SharedRoutine(
         routineId = UUID.randomUUID().toString(),
-        title = title,
-        author = author,
-        description = description,
+        title = title.toString(),
+        author = author.toString(),
+        description = description.toString(),
         modifiedDate = LocalDateTime.now(),
     )
 }

--- a/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
+++ b/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
@@ -6,6 +6,7 @@ import com.lateinit.rightweight.data.database.entity.Exercise
 import com.lateinit.rightweight.data.database.entity.ExerciseSet
 import com.lateinit.rightweight.data.database.entity.SharedRoutine
 import com.lateinit.rightweight.data.database.intermediate.ExerciseWithSets
+import com.lateinit.rightweight.data.model.DetailResponse
 import com.lateinit.rightweight.data.model.RoutineCollection
 import com.lateinit.rightweight.data.remote.model.SharedRoutineField
 import com.lateinit.rightweight.ui.model.DayUiModel
@@ -74,12 +75,13 @@ fun ExerciseSetUiModel.toExerciseSet(): ExerciseSet {
     )
 }
 
-fun SharedRoutineField.toSharedRoutine(): SharedRoutine{
+fun DetailResponse<SharedRoutineField>.toSharedRoutine(): SharedRoutine{
+    val splitedName = name.split("/")
     return SharedRoutine(
-        routineId = UUID.randomUUID().toString(),
-        title = title.toString(),
-        author = author.toString(),
-        description = description.toString(),
-        modifiedDate = LocalDateTime.now(),
+        routineId = splitedName[splitedName.size-1],
+        title = fields.title.toString(),
+        author = fields.author.toString(),
+        description = fields.description.toString(),
+        modifiedDate = LocalDateTime.now()
     )
 }

--- a/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
+++ b/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
@@ -6,7 +6,6 @@ import com.lateinit.rightweight.data.database.entity.Exercise
 import com.lateinit.rightweight.data.database.entity.ExerciseSet
 import com.lateinit.rightweight.data.database.entity.SharedRoutine
 import com.lateinit.rightweight.data.database.intermediate.ExerciseWithSets
-import com.lateinit.rightweight.data.model.Documents
 import com.lateinit.rightweight.data.model.RoutineCollection
 import com.lateinit.rightweight.ui.model.DayUiModel
 import com.lateinit.rightweight.ui.model.ExerciseSetUiModel


### PR DESCRIPTION
- close #83 

1. firestore rest api에 특정 조건에 해당하는 데이터를 가져오도록 요청하여 paging3 구현
공유된 루틴을 시간순으로 10개씩 가져오는 작업을 하기 위해
https://firestore.googleapis.com/v1/projects/right-weight/databases/(default)/documents:runQuery 사용
Body로 limit(개수 제한), orderBy(정렬 기준), startAt(불러오는 시작 위치 설정) 을 설정하여 요청할 수 있다.
orderBy를 modified_date 기준으로 하고 timestampValue 기준으로 startAt 설정 시 해당 시간보다 이후의 시간을 modified_date로 갖는 루틴만 가져온다.
테이블에 10개 중 마지막 루틴의 modified_date를 저장 후 다음에 10개를 호출할 때 저장된 modified_date 이후와 관련된 루틴만 가져오게 해서 paging을 구현할 수 있다.

2. firestore rest api에서 데이터를 받아서 Room에 저장하는 로직을 테스트하기 위해 AndroidTest 활용
HiltAndroidTest에서 Hilt 사용하기 위해서 다음 과정 필요
class CustomTestRunner : AndroidJUnitRunner() {
    override fun newApplication(cl: ClassLoader?, name: String?, context: Context?): Application {
        return super.newApplication(cl, HiltTestApplication::class.java.name, context)
    }
}
android {
    defaultConfig {
        // Replace com.example.android.dagger with your class path.
        testInstrumentationRunner = "com.example.android.dagger.CustomTestRunner"
    }
}
hiltRule 설정 후 inject 하여 @Inject 표시된 lateinit var 객체가 생성되게 함
database도 hilt를 사용하여 생성할 수 있으나, 실제 앱 데이터베이스에 접근하기 때문에 정확한 테스트를 위해 매번 데이터베이스 내부를 초기화하는 작업이 요구된다.
이 부분은 hilt를 사용하지 않고 Test 도중에만 메모리에서 유효한 개별 database를 만들어서 Test 종료 시 초기화 되도록 하는 것이 좋다.
        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().context,
            AppDatabase::class.java).build()
suspend 관련 함수를 테스트할 경우 runblocking을 활용할 수 있다.
hilt를 사용하여 접근한 routineApiService에서 공유된 루틴 목록을 가져와서 메모리 상에 있는 Room에 저장하고,
Room에서 공유된 루틴 목록을 불러오는 함수를 호출하여 앞의 데이터와 비교하는 테스트를 진행할 수 있다.