### PR TITLE
[파이어스토어] 하위 컬렉션 문서명 가져와 삭제

### DIFF
--- a/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
@@ -1,12 +1,15 @@
 package com.lateinit.rightweight.data
 
 import com.lateinit.rightweight.data.database.mediator.SharedRoutineRequestBody
+import com.lateinit.rightweight.data.model.DetailResponse
 import com.lateinit.rightweight.data.model.DocumentResponse
-import com.lateinit.rightweight.data.model.RoutineCollection
+import com.lateinit.rightweight.data.model.DocumentsListResponse
+import com.lateinit.rightweight.data.remote.model.RemoteData
 import com.lateinit.rightweight.data.remote.model.SharedRoutineField
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface RoutineApiService {
 
@@ -20,4 +23,10 @@ interface RoutineApiService {
     suspend fun getSharedRoutines(
         @Body order: SharedRoutineRequestBody
     ): List<DocumentResponse<SharedRoutineField>>
+
+    @GET("documents/shared_routine/{path}")
+    suspend fun getChildrenDocumentName(
+        @Path(value = "path", encoded = true)
+        path: String
+    ): DocumentsListResponse<DetailResponse<RemoteData>>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
@@ -10,6 +10,7 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.DELETE
 
 interface RoutineApiService {
 
@@ -29,4 +30,10 @@ interface RoutineApiService {
         @Path(value = "path", encoded = true)
         path: String
     ): DocumentsListResponse<DetailResponse<RemoteData>>
+
+    @DELETE("documents/shared_routine/{path}")
+    suspend fun deleteDocument(
+        @Path(value = "path", encoded = true)
+        path: String
+    )
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSource.kt
@@ -6,4 +6,5 @@ import kotlinx.coroutines.flow.Flow
 
 interface RoutineRemoteDataSource {
     fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>>
+    suspend fun getChildrenDocumentName(path: String):List<String>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSource.kt
@@ -7,4 +7,5 @@ import kotlinx.coroutines.flow.Flow
 interface RoutineRemoteDataSource {
     fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>>
     suspend fun getChildrenDocumentName(path: String):List<String>
+    suspend fun deleteDocument(path: String)
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
@@ -13,7 +13,7 @@ class RoutineRemoteDataSourceImpl @Inject constructor(
     private val db: AppDatabase,
     private val api: RoutineApiService,
     private val appSharedPreferences: AppSharedPreferences
-): RoutineRemoteDataSource {
+) : RoutineRemoteDataSource {
 
 
     @OptIn(ExperimentalPagingApi::class)
@@ -25,4 +25,14 @@ class RoutineRemoteDataSourceImpl @Inject constructor(
     ) {
         db.sharedRoutineDao().getAllSharedRoutinesByPaging()
     }.flow
+
+    override suspend fun getChildrenDocumentName(path: String): List<String> {
+        val a = api.getChildrenDocumentName(path)
+        val documentName = a.documents.map {
+            it.name.split("/").last()
+        }
+
+
+        return documentName
+    }
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
@@ -27,12 +27,14 @@ class RoutineRemoteDataSourceImpl @Inject constructor(
     }.flow
 
     override suspend fun getChildrenDocumentName(path: String): List<String> {
-        val a = api.getChildrenDocumentName(path)
-        val documentName = a.documents.map {
+        val documentNameList = api.getChildrenDocumentName(path)
+        val documentIdList = documentNameList.documents.map {
             it.name.split("/").last()
         }
+        return documentIdList
+    }
 
-
-        return documentName
+    override suspend fun deleteDocument(path: String) {
+        api.deleteDocument(path)
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
@@ -7,6 +7,7 @@ import com.lateinit.rightweight.data.RoutineApiService
 import com.lateinit.rightweight.data.database.AppDatabase
 import com.lateinit.rightweight.data.database.AppSharedPreferences
 import com.lateinit.rightweight.data.database.mediator.SharedRoutineRemoteMediator
+import com.lateinit.rightweight.data.remote.model.RootField
 import javax.inject.Inject
 
 class RoutineRemoteDataSourceImpl @Inject constructor(

--- a/app/src/main/java/com/lateinit/rightweight/data/model/Documents.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/model/Documents.kt
@@ -3,3 +3,6 @@ package com.lateinit.rightweight.data.model
 data class DocumentResponse<T>(val document: DetailResponse<T>)
 
 data class DetailResponse<T> (val name: String, val fields: T)
+
+data class DocumentsListResponse<T> (val documents: List<DetailResponse<T>>)
+

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
@@ -6,4 +6,5 @@ import kotlinx.coroutines.flow.Flow
 
 interface SharedRoutineRepository {
     suspend fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>>
+    suspend fun getChildrenDocumentName(path: String): List<String>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
@@ -7,4 +7,5 @@ import kotlinx.coroutines.flow.Flow
 interface SharedRoutineRepository {
     suspend fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>>
     suspend fun getChildrenDocumentName(path: String): List<String>
+    suspend fun deleteDocument(path: String)
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
@@ -12,4 +12,8 @@ class SharedRoutineRepositoryImpl @Inject constructor(
     override suspend fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>> {
         return routineRemoteDataSource.getSharedRoutinesByPaging()
     }
+
+    override suspend fun getChildrenDocumentName(path: String): List<String> {
+        return routineRemoteDataSource.getChildrenDocumentName(path)
+    }
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.lateinit.rightweight.data.repository
 
 import androidx.paging.PagingData
+import com.lateinit.rightweight.data.database.entity.Routine
 import com.lateinit.rightweight.data.database.entity.SharedRoutine
 import com.lateinit.rightweight.data.datasource.RoutineRemoteDataSource
 import com.lateinit.rightweight.data.remote.model.DayField

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
@@ -16,4 +16,8 @@ class SharedRoutineRepositoryImpl @Inject constructor(
     override suspend fun getChildrenDocumentName(path: String): List<String> {
         return routineRemoteDataSource.getChildrenDocumentName(path)
     }
+
+    override suspend fun deleteDocument(path: String) {
+        routineRemoteDataSource.deleteDocument(path)
+    }
 }

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailFragment.kt
@@ -83,6 +83,11 @@ class RoutineDetailFragment : Fragment(){
                         removeRoutine(args.routineId)
                         return true
                     }
+                    R.id.action_item_share -> {
+
+                        routineDetailViewModel.deleteSharedRoutineAndDays()
+                        return true
+                    }
                     else -> {
                         return false
                     }

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailViewModel.kt
@@ -75,37 +75,43 @@ class RoutineDetailViewModel @Inject constructor(
         _currentDayPosition.value = _currentDayPosition.value
     }
 
-    fun removeRoutine(routineId: String){
+    fun removeRoutine(routineId: String) {
         viewModelScope.launch {
             routineRepository.removeRoutineById(routineId)
         }
     }
 
-    fun getDaysDocumentName(){
+    fun deleteSharedRoutineAndDays() {
         viewModelScope.launch {
             val routineId = _routine.value?.routineId ?: return@launch
+            sharedRoutineRepository.deleteDocument(routineId)
             val path = "${routineId}/day"
             val dayDocuments = sharedRoutineRepository.getChildrenDocumentName(path)
             dayDocuments.forEach { dayId ->
-                getExerciseDocumentName(routineId, dayId)
+                deleteSharedExercise(routineId, dayId)
+                sharedRoutineRepository.deleteDocument("${routineId}/day/${dayId}")
             }
         }
     }
 
-    private fun getExerciseDocumentName(routineId: String, dayId: String) {
+    private fun deleteSharedExercise(routineId: String, dayId: String) {
         viewModelScope.launch {
             val path = "${routineId}/day/${dayId}/exercise"
             val exerciseDocuments = sharedRoutineRepository.getChildrenDocumentName(path)
             exerciseDocuments.forEach { exerciseId ->
-                getExerciseSetDocumentName(routineId, dayId,exerciseId)
+                deleteSharedExerciseSet(routineId, dayId, exerciseId)
+                sharedRoutineRepository.deleteDocument("${routineId}/day/${dayId}/exercise/${exerciseId}")
             }
         }
     }
 
-    private fun getExerciseSetDocumentName(routineId: String, dayId: String, exerciseId: String) {
+    private fun deleteSharedExerciseSet(routineId: String, dayId: String, exerciseId: String) {
         viewModelScope.launch {
             val path = "${routineId}/day/${dayId}/exercise/${exerciseId}/exercise_set"
             val exerciseSetDocuments = sharedRoutineRepository.getChildrenDocumentName(path)
+            exerciseSetDocuments.forEach { exerciseSetId ->
+                sharedRoutineRepository.deleteDocument("${routineId}/day/${dayId}/exercise/${exerciseId}/exercise_set/${exerciseSetId}")
+            }
         }
     }
 

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lateinit.rightweight.data.database.entity.Routine
 import com.lateinit.rightweight.data.repository.RoutineRepository
+import com.lateinit.rightweight.data.repository.SharedRoutineRepository
 import com.lateinit.rightweight.ui.model.DayUiModel
 import com.lateinit.rightweight.util.FIRST_DAY_POSITION
 import com.lateinit.rightweight.util.toDayUiModel
@@ -16,7 +17,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class RoutineDetailViewModel @Inject constructor(
-    private val routineRepository: RoutineRepository
+    private val routineRepository: RoutineRepository,
+    private val sharedRoutineRepository: SharedRoutineRepository
 ) : ViewModel() {
 
     private val _routine = MutableLiveData<Routine>()
@@ -78,5 +80,34 @@ class RoutineDetailViewModel @Inject constructor(
             routineRepository.removeRoutineById(routineId)
         }
     }
+
+    fun getDaysDocumentName(){
+        viewModelScope.launch {
+            val routineId = _routine.value?.routineId ?: return@launch
+            val path = "${routineId}/day"
+            val dayDocuments = sharedRoutineRepository.getChildrenDocumentName(path)
+            dayDocuments.forEach { dayId ->
+                getExerciseDocumentName(routineId, dayId)
+            }
+        }
+    }
+
+    private fun getExerciseDocumentName(routineId: String, dayId: String) {
+        viewModelScope.launch {
+            val path = "${routineId}/day/${dayId}/exercise"
+            val exerciseDocuments = sharedRoutineRepository.getChildrenDocumentName(path)
+            exerciseDocuments.forEach { exerciseId ->
+                getExerciseSetDocumentName(routineId, dayId,exerciseId)
+            }
+        }
+    }
+
+    private fun getExerciseSetDocumentName(routineId: String, dayId: String, exerciseId: String) {
+        viewModelScope.launch {
+            val path = "${routineId}/day/${dayId}/exercise/${exerciseId}/exercise_set"
+            val exerciseSetDocuments = sharedRoutineRepository.getChildrenDocumentName(path)
+        }
+    }
+
 }
 


### PR DESCRIPTION
- close #99 

- GET으로 해당 컬렉션의 하위 document들 리스트를 받아와 각 document를 delete하는 쿼리를 한번 더 요청 했습니다.
- 공유 함수처럼 연쇄적으로 하위 document를 호출해서 삭제하도록 구현 됐는데 둘 다 하나의 함수로 처리할 수 있도록 수정 가능 할 것 같아 다른 이슈로 처리 해 보겠습니다.
- 다음 이슈에서 공유를 눌렀을 때 이미 서버에 해당 routineID로 공유된 루틴이 있다면 해당 루틴의 정보를 모두 지우고 새로 넣도록 구현할 계획 입니다.