### PR TITLE
[공유된 루틴 열람 화면] 커뮤니티 화면에서 받은 routine_id로 서버에 요청하여 받은 결과를 화면에 표시

### DIFF
--- a/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
+++ b/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
@@ -8,6 +8,9 @@ import com.lateinit.rightweight.data.database.AppDatabase
 import com.lateinit.rightweight.data.database.mediator.*
 import com.lateinit.rightweight.data.datasource.RoutineRemoteDataSourceImpl
 import com.lateinit.rightweight.util.toSharedRoutine
+import com.lateinit.rightweight.util.toSharedRoutineDay
+import com.lateinit.rightweight.util.toSharedRoutineExercise
+import com.lateinit.rightweight.util.toSharedRoutineExerciseSet
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import junit.framework.Assert.assertEquals
@@ -32,8 +35,6 @@ class SharedRoutineTest {
     @Inject
     lateinit var routineApiService: RoutineApiService
 
-//    @Inject
-//    lateinit var db: AppDatabase
     lateinit var db: AppDatabase
 
     @Before
@@ -71,6 +72,38 @@ class SharedRoutineTest {
             println(db.sharedRoutineDao().getAllSharedRoutines())
 
             //assertEquals("DB_COMPLETE", documentResponses, db.sharedRoutineDao().getAllSharedRoutines())
+        }
+    }
+
+    @Test
+    fun sharedRoutineDetailTest() {
+        runBlocking {
+            val sharedRoutineDaysResponse = routineApiService.getSharedRoutineDays(
+                "07fd07ab-45c6-4479-881a-abe151a82456"
+            )
+            sharedRoutineDaysResponse.documents.forEach(){
+                val sharedRoutineDay = it.toSharedRoutineDay()
+                println(sharedRoutineDay.toString())
+                val sharedRoutineExercisesResponse= routineApiService.getSharedRoutineExercises(
+                    sharedRoutineDay.routineId,
+                    sharedRoutineDay.dayId
+                )
+                println(sharedRoutineExercisesResponse.toString())
+                sharedRoutineExercisesResponse.documents.forEach(){
+                    val sharedRoutineExercise = it.toSharedRoutineExercise()
+                    println(sharedRoutineExercise.toString())
+                    val sharedRoutineExerciseSetsResponse = routineApiService.getSharedRoutineExerciseSets(
+                        sharedRoutineDay.routineId,
+                        sharedRoutineExercise.dayId,
+                        sharedRoutineExercise.exerciseId
+                    )
+                   sharedRoutineExerciseSetsResponse.documents.forEach(){
+                       val sharedRoutineExerciseSet = it.toSharedRoutineExerciseSet()
+                       println(sharedRoutineExerciseSet.toString())
+                   }
+                }
+            }
+
         }
     }
 

--- a/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
+++ b/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
@@ -14,6 +14,7 @@ import com.lateinit.rightweight.util.toSharedRoutineExerciseSet
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import junit.framework.Assert.assertEquals
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
@@ -104,6 +105,15 @@ class SharedRoutineTest {
                 }
             }
 
+        }
+    }
+
+    @Test
+    fun flowTest(){
+        runBlocking {
+            routineRemoteDataSourceImpl.getSharedRoutineDays("07fd07ab-45c6-4479-881a-abe151a82456").collect(){
+                println(it.toString())
+            }
         }
     }
 

--- a/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
+++ b/app/src/androidTest/java/com/lateinit/rightweight/SharedRoutineTest.kt
@@ -64,7 +64,7 @@ class SharedRoutineTest {
             )
             println(documentResponses.toString())
 
-            documentResponses.forEach() { documentResponse ->
+            documentResponses?.forEach() { documentResponse ->
                 db.sharedRoutineDao()
                     .insertSharedRoutine(documentResponse.document.toSharedRoutine())
             }
@@ -81,7 +81,7 @@ class SharedRoutineTest {
             val sharedRoutineDaysResponse = routineApiService.getSharedRoutineDays(
                 "07fd07ab-45c6-4479-881a-abe151a82456"
             )
-            sharedRoutineDaysResponse.documents.forEach(){
+            sharedRoutineDaysResponse?.documents?.forEach(){
                 val sharedRoutineDay = it.toSharedRoutineDay()
                 println(sharedRoutineDay.toString())
                 val sharedRoutineExercisesResponse= routineApiService.getSharedRoutineExercises(
@@ -89,7 +89,7 @@ class SharedRoutineTest {
                     sharedRoutineDay.dayId
                 )
                 println(sharedRoutineExercisesResponse.toString())
-                sharedRoutineExercisesResponse.documents.forEach(){
+                sharedRoutineExercisesResponse?.documents?.forEach(){
                     val sharedRoutineExercise = it.toSharedRoutineExercise()
                     println(sharedRoutineExercise.toString())
                     val sharedRoutineExerciseSetsResponse = routineApiService.getSharedRoutineExerciseSets(
@@ -97,7 +97,7 @@ class SharedRoutineTest {
                         sharedRoutineExercise.dayId,
                         sharedRoutineExercise.exerciseId
                     )
-                   sharedRoutineExerciseSetsResponse.documents.forEach(){
+                   sharedRoutineExerciseSetsResponse?.documents?.forEach(){
                        val sharedRoutineExerciseSet = it.toSharedRoutineExerciseSet()
                        println(sharedRoutineExerciseSet.toString())
                    }

--- a/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
@@ -24,23 +24,23 @@ interface RoutineApiService {
     @POST("./documents:runQuery")
     suspend fun getSharedRoutines(
         @Body order: SharedRoutineRequestBody
-    ): List<DocumentResponse<SharedRoutineField>>
+    ): List<DocumentResponse<SharedRoutineField>>?
 
     @GET("documents/shared_routine/{routineId}/day")
     suspend fun getSharedRoutineDays(
         @Path("routineId") routineId: String
-    ): DocumentsResponse<SharedRoutineDayField>
+    ): DocumentsResponse<SharedRoutineDayField>?
 
     @GET("documents/shared_routine/{routineId}/day/{dayId}/exercise")
     suspend fun getSharedRoutineExercises(
         @Path("routineId") routineId: String,
         @Path("dayId") dayId: String
-    ): DocumentsResponse<SharedRoutineExerciseField>
+    ): DocumentsResponse<SharedRoutineExerciseField>?
 
     @GET("documents/shared_routine/{routineId}/day/{dayId}/exercise/{exerciseId}/exercise_set")
     suspend fun getSharedRoutineExerciseSets(
         @Path("routineId") routineId: String,
         @Path("dayId") dayId: String,
         @Path("exerciseId") exerciseId: String
-    ): DocumentsResponse<SharedRoutineExerciseSetField>
+    ): DocumentsResponse<SharedRoutineExerciseSetField>?
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
@@ -2,11 +2,16 @@ package com.lateinit.rightweight.data
 
 import com.lateinit.rightweight.data.database.mediator.SharedRoutineRequestBody
 import com.lateinit.rightweight.data.model.DocumentResponse
+import com.lateinit.rightweight.data.model.DocumentsResponse
 import com.lateinit.rightweight.data.model.RoutineCollection
+import com.lateinit.rightweight.data.remote.model.SharedRoutineDayField
+import com.lateinit.rightweight.data.remote.model.SharedRoutineExerciseField
+import com.lateinit.rightweight.data.remote.model.SharedRoutineExerciseSetField
 import com.lateinit.rightweight.data.remote.model.SharedRoutineField
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface RoutineApiService {
 
@@ -20,4 +25,22 @@ interface RoutineApiService {
     suspend fun getSharedRoutines(
         @Body order: SharedRoutineRequestBody
     ): List<DocumentResponse<SharedRoutineField>>
+
+    @GET("documents/shared_routine/{routineId}/day")
+    suspend fun getSharedRoutineDays(
+        @Path("routineId") routineId: String
+    ): DocumentsResponse<SharedRoutineDayField>
+
+    @GET("documents/shared_routine/{routineId}/day/{dayId}/exercise")
+    suspend fun getSharedRoutineExercises(
+        @Path("routineId") routineId: String,
+        @Path("dayId") dayId: String
+    ): DocumentsResponse<SharedRoutineExerciseField>
+
+    @GET("documents/shared_routine/{routineId}/day/{dayId}/exercise/{exerciseId}/exercise_set")
+    suspend fun getSharedRoutineExerciseSets(
+        @Path("routineId") routineId: String,
+        @Path("dayId") dayId: String,
+        @Path("exerciseId") exerciseId: String
+    ): DocumentsResponse<SharedRoutineExerciseSetField>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/RoutineApiService.kt
@@ -3,9 +3,8 @@ package com.lateinit.rightweight.data
 import com.lateinit.rightweight.data.database.mediator.SharedRoutineRequestBody
 import com.lateinit.rightweight.data.model.DetailResponse
 import com.lateinit.rightweight.data.model.DocumentResponse
-import com.lateinit.rightweight.data.remote.model.RemoteData
 import com.lateinit.rightweight.data.model.DocumentsResponse
-import com.lateinit.rightweight.data.remote.model.SharedRoutineField
+import com.lateinit.rightweight.data.remote.model.*
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST

--- a/app/src/main/java/com/lateinit/rightweight/data/database/AppDatabase.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/AppDatabase.kt
@@ -12,7 +12,7 @@ import com.lateinit.rightweight.data.database.entity.*
     entities = [
         Routine::class, Day::class, Exercise::class, ExerciseSet::class,
         History::class, HistoryExercise::class, HistorySet::class,
-        SharedRoutine::class
+        SharedRoutine::class, SharedRoutineDay::class, SharedRoutineExercise::class, SharedRoutineExerciseSet::class
     ],
     version = 1,
     exportSchema = false

--- a/app/src/main/java/com/lateinit/rightweight/data/database/dao/SharedRoutineDao.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/dao/SharedRoutineDao.kt
@@ -1,20 +1,27 @@
 package com.lateinit.rightweight.data.database.dao
 
 import androidx.paging.PagingSource
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
+import androidx.room.*
 import com.lateinit.rightweight.data.database.entity.SharedRoutine
+import com.lateinit.rightweight.data.database.entity.SharedRoutineDay
+import com.lateinit.rightweight.data.database.entity.SharedRoutineExercise
+import com.lateinit.rightweight.data.database.entity.SharedRoutineExerciseSet
+import com.lateinit.rightweight.data.database.intermediate.SharedRoutineDayWithExercises
+import com.lateinit.rightweight.data.database.intermediate.SharedRoutineWithDays
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface SharedRoutineDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertSharedRoutine(
         sharedRoutine: SharedRoutine,
-//        days: List<SharedDay>,
-//        exercises: List<SharedExercise>,
-//        sets: List<SharedExerciseSet>
+    )
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSharedRoutineDetail(
+        days: List<SharedRoutineDay>,
+        exercises: List<SharedRoutineExercise>,
+        sets: List<SharedRoutineExerciseSet>
     )
 
     @Query("DELETE FROM shared_routine")
@@ -25,4 +32,8 @@ interface SharedRoutineDao {
 
     @Query("SELECT * FROM shared_routine")
     fun getAllSharedRoutines(): List<SharedRoutine>
+
+    @Transaction
+    @Query("SELECT * FROM shared_routine WHERE routine_id = :routineId")
+    fun getSharedRoutineWithDaysByRoutineId(routineId: String): Flow<SharedRoutineWithDays>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/database/dao/SharedRoutineDao.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/dao/SharedRoutineDao.kt
@@ -5,9 +5,6 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import com.lateinit.rightweight.data.database.entity.SharedDay
-import com.lateinit.rightweight.data.database.entity.SharedExercise
-import com.lateinit.rightweight.data.database.entity.SharedExerciseSet
 import com.lateinit.rightweight.data.database.entity.SharedRoutine
 
 @Dao

--- a/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedRoutineDay.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedRoutineDay.kt
@@ -6,7 +6,7 @@ import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
 
 @Entity(
-    tableName = "shared_day",
+    tableName = "shared_routine_day",
     foreignKeys = [
         ForeignKey(
             entity = SharedRoutine::class,
@@ -15,7 +15,7 @@ import androidx.room.PrimaryKey
         )
     ]
 )
-data class SharedDay(
+data class SharedRoutineDay(
     @PrimaryKey
     @ColumnInfo(name = "day_id")
     val dayId: String,

--- a/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedRoutineDay.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedRoutineDay.kt
@@ -12,6 +12,7 @@ import androidx.room.PrimaryKey
             entity = SharedRoutine::class,
             parentColumns = ["routine_id"],
             childColumns = ["routine_id"],
+            onDelete = ForeignKey.CASCADE
         )
     ]
 )

--- a/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedRoutineExercise.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedRoutineExercise.kt
@@ -7,17 +7,17 @@ import androidx.room.PrimaryKey
 import com.lateinit.rightweight.data.ExercisePartType
 
 @Entity(
-    tableName = "shared_exercise",
+    tableName = "shared_routine_exercise",
     foreignKeys = [
         ForeignKey(
-            entity = SharedDay::class,
+            entity = SharedRoutineDay::class,
             parentColumns = ["day_id"],
             childColumns = ["day_id"],
             onDelete = ForeignKey.CASCADE
         )
     ]
 )
-data class SharedExercise(
+data class SharedRoutineExercise(
     @PrimaryKey
     @ColumnInfo(name = "exercise_id")
     val exerciseId: String,

--- a/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedRoutineExerciseSet.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/entity/SharedRoutineExerciseSet.kt
@@ -6,17 +6,17 @@ import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
 
 @Entity(
-    tableName = "shared_exercise_set",
+    tableName = "shared_routine_exercise_set",
     foreignKeys = [
         ForeignKey(
-            entity = SharedExercise::class,
+            entity = SharedRoutineExercise::class,
             parentColumns = ["exercise_id"],
             childColumns = ["exercise_id"],
             onDelete = ForeignKey.CASCADE
         )
     ]
 )
-data class SharedExerciseSet(
+data class SharedRoutineExerciseSet(
     @PrimaryKey
     @ColumnInfo(name = "set_id")
     val setId: String,

--- a/app/src/main/java/com/lateinit/rightweight/data/database/intermediate/SharedRoutineDayWithExercises.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/intermediate/SharedRoutineDayWithExercises.kt
@@ -1,0 +1,16 @@
+package com.lateinit.rightweight.data.database.intermediate
+
+import androidx.room.Embedded
+import androidx.room.Relation
+import com.lateinit.rightweight.data.database.entity.*
+
+data class SharedRoutineDayWithExercises(
+    @Embedded val day: SharedRoutineDay,
+
+    @Relation(
+        entity = SharedRoutineExercise::class,
+        parentColumn = "day_id",
+        entityColumn = "day_id"
+    )
+    val exercises: List<SharedRoutineExerciseWithExerciseSets>
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/database/intermediate/SharedRoutineExerciseWithExerciseSets.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/intermediate/SharedRoutineExerciseWithExerciseSets.kt
@@ -1,0 +1,18 @@
+package com.lateinit.rightweight.data.database.intermediate
+
+import androidx.room.Embedded
+import androidx.room.Relation
+import com.lateinit.rightweight.data.database.entity.SharedRoutineDay
+import com.lateinit.rightweight.data.database.entity.SharedRoutineExercise
+import com.lateinit.rightweight.data.database.entity.SharedRoutineExerciseSet
+
+data class SharedRoutineExerciseWithExerciseSets(
+    @Embedded val exercise: SharedRoutineExercise,
+
+    @Relation(
+        entity = SharedRoutineExerciseSet::class,
+        parentColumn = "exercise_id",
+        entityColumn = "exercise_id"
+    )
+    val sets: List<SharedRoutineExerciseSet>
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/database/intermediate/SharedRoutineWithDays.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/intermediate/SharedRoutineWithDays.kt
@@ -1,0 +1,17 @@
+package com.lateinit.rightweight.data.database.intermediate
+
+import androidx.room.Embedded
+import androidx.room.Relation
+import com.lateinit.rightweight.data.database.entity.SharedRoutine
+import com.lateinit.rightweight.data.database.entity.SharedRoutineDay
+
+data class SharedRoutineWithDays(
+    @Embedded val routine: SharedRoutine,
+
+    @Relation(
+        entity = SharedRoutineDay::class,
+        parentColumn = "routine_id",
+        entityColumn = "routine_id"
+    )
+    val days: List<SharedRoutineDayWithExercises>
+)

--- a/app/src/main/java/com/lateinit/rightweight/data/database/mediator/SharedRoutineRemoteMediator.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/mediator/SharedRoutineRemoteMediator.kt
@@ -60,7 +60,7 @@ class SharedRoutineRemoteMediator(
                     db.sharedRoutineDao().removeAllSharedRoutines()
                 }
 
-                documentResponses.forEach() { documentResponse ->
+                documentResponses?.forEach() { documentResponse ->
                     db.sharedRoutineDao()
                         .insertSharedRoutine(documentResponse.document.toSharedRoutine())
                     pagingFlag = documentResponse.document.fields.modifiedDate.toString()
@@ -68,7 +68,12 @@ class SharedRoutineRemoteMediator(
                 appSharedPreferences.setSharedRoutinePagingFlag(pagingFlag)
             }
 
-            return MediatorResult.Success(endOfPaginationReached = documentResponses.isEmpty())
+            if (documentResponses != null) {
+                return MediatorResult.Success(endOfPaginationReached = documentResponses.isEmpty())
+            }
+            else{
+                return MediatorResult.Success(endOfPaginationReached = true)
+            }
         } catch (e: IOException) {
             return MediatorResult.Error(e)
         } catch (e: HttpException) {

--- a/app/src/main/java/com/lateinit/rightweight/data/database/mediator/SharedRoutineRemoteMediator.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/mediator/SharedRoutineRemoteMediator.kt
@@ -23,7 +23,7 @@ class SharedRoutineRemoteMediator(
     private val initModifiedDateFlag = "1-1-1T1:1:1.1Z"
 
     override suspend fun initialize(): InitializeAction {
-        return InitializeAction.SKIP_INITIAL_REFRESH
+        return InitializeAction.LAUNCH_INITIAL_REFRESH
     }
 
     override suspend fun load(

--- a/app/src/main/java/com/lateinit/rightweight/data/database/mediator/SharedRoutineRemoteMediator.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/mediator/SharedRoutineRemoteMediator.kt
@@ -31,12 +31,17 @@ class SharedRoutineRemoteMediator(
         state: PagingState<Int, SharedRoutine>
     ): MediatorResult {
         try {
-            var pagingFlag= when (loadType) {
+            var endOfPaginationReached = false
+
+            var pagingFlag = when (loadType) {
                 LoadType.REFRESH -> initModifiedDateFlag
-                LoadType.PREPEND -> return MediatorResult.Success(endOfPaginationReached = true)
+                LoadType.PREPEND -> {
+                    endOfPaginationReached = true
+                    return MediatorResult.Success(endOfPaginationReached = endOfPaginationReached)
+                }
                 LoadType.APPEND -> {
                     val flag = appSharedPreferences.getSharedRoutinePagingFlag()
-                    if(flag.isNullOrEmpty()) initModifiedDateFlag
+                    if (flag.isNullOrEmpty()) initModifiedDateFlag
                     else flag
                 }
             }
@@ -60,19 +65,23 @@ class SharedRoutineRemoteMediator(
                     db.sharedRoutineDao().removeAllSharedRoutines()
                 }
 
-                documentResponses?.forEach() { documentResponse ->
-                    db.sharedRoutineDao()
-                        .insertSharedRoutine(documentResponse.document.toSharedRoutine())
-                    pagingFlag = documentResponse.document.fields.modifiedDate.toString()
+                documentResponses?.forEach { documentResponse ->
+                    if (documentResponse.document != null) {
+                        db.sharedRoutineDao()
+                            .insertSharedRoutine(documentResponse.document.toSharedRoutine())
+                        pagingFlag = documentResponse.document.fields.modifiedDate?.value.toString()
+                    } else {
+                        endOfPaginationReached = true
+                    }
                 }
                 appSharedPreferences.setSharedRoutinePagingFlag(pagingFlag)
             }
 
-            if (documentResponses != null) {
-                return MediatorResult.Success(endOfPaginationReached = documentResponses.isEmpty())
-            }
-            else{
-                return MediatorResult.Success(endOfPaginationReached = true)
+            return if (documentResponses != null) {
+                MediatorResult.Success(endOfPaginationReached = endOfPaginationReached)
+            } else {
+                endOfPaginationReached = true
+                MediatorResult.Success(endOfPaginationReached = true)
             }
         } catch (e: IOException) {
             return MediatorResult.Error(e)

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineLocalDataSource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineLocalDataSource.kt
@@ -33,5 +33,5 @@ interface RoutineLocalDataSource {
         exercises: List<SharedRoutineExercise>,
         sets: List<SharedRoutineExerciseSet>
     )
-    suspend fun getSharedRoutineWithDaysByRoutineId(routineId: String): Flow<SharedRoutineWithDays>
+    fun getSharedRoutineWithDaysByRoutineId(routineId: String): Flow<SharedRoutineWithDays>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineLocalDataSource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineLocalDataSource.kt
@@ -1,11 +1,11 @@
 package com.lateinit.rightweight.data.datasource
 
-import com.lateinit.rightweight.data.database.entity.Day
-import com.lateinit.rightweight.data.database.entity.Exercise
-import com.lateinit.rightweight.data.database.entity.ExerciseSet
-import com.lateinit.rightweight.data.database.entity.Routine
+import com.lateinit.rightweight.data.database.entity.*
 import com.lateinit.rightweight.data.database.intermediate.DayWithExercises
 import com.lateinit.rightweight.data.database.intermediate.RoutineWithDays
+import com.lateinit.rightweight.data.database.intermediate.SharedRoutineDayWithExercises
+import com.lateinit.rightweight.data.database.intermediate.SharedRoutineWithDays
+import kotlinx.coroutines.flow.Flow
 
 interface RoutineLocalDataSource {
 
@@ -27,4 +27,11 @@ interface RoutineLocalDataSource {
     suspend fun getRoutineWithDaysByRoutineId(routineId: String): RoutineWithDays
     suspend fun getDayWithExercisesByDayId(dayId: String): DayWithExercises
     suspend fun removeRoutineById(routineId: String)
+
+    suspend fun insertSharedRoutineDetail(
+        days: List<SharedRoutineDay>,
+        exercises: List<SharedRoutineExercise>,
+        sets: List<SharedRoutineExerciseSet>
+    )
+    suspend fun getSharedRoutineWithDaysByRoutineId(routineId: String): Flow<SharedRoutineWithDays>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineLocalDataSourceImpl.kt
@@ -75,7 +75,7 @@ class RoutineLocalDataSourceImpl @Inject constructor(
        sharedRoutineDao.insertSharedRoutineDetail(days, exercises, sets)
     }
 
-    override suspend fun getSharedRoutineWithDaysByRoutineId(routineId: String): Flow<SharedRoutineWithDays> {
+    override fun getSharedRoutineWithDaysByRoutineId(routineId: String): Flow<SharedRoutineWithDays> {
         return sharedRoutineDao.getSharedRoutineWithDaysByRoutineId(routineId)
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineLocalDataSourceImpl.kt
@@ -1,16 +1,17 @@
 package com.lateinit.rightweight.data.datasource
 
 import com.lateinit.rightweight.data.database.dao.RoutineDao
-import com.lateinit.rightweight.data.database.entity.Day
-import com.lateinit.rightweight.data.database.entity.Exercise
-import com.lateinit.rightweight.data.database.entity.ExerciseSet
-import com.lateinit.rightweight.data.database.entity.Routine
+import com.lateinit.rightweight.data.database.dao.SharedRoutineDao
+import com.lateinit.rightweight.data.database.entity.*
 import com.lateinit.rightweight.data.database.intermediate.DayWithExercises
 import com.lateinit.rightweight.data.database.intermediate.RoutineWithDays
+import com.lateinit.rightweight.data.database.intermediate.SharedRoutineWithDays
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class RoutineLocalDataSourceImpl @Inject constructor(
     private val routineDao: RoutineDao,
+    private val sharedRoutineDao: SharedRoutineDao
 ) : RoutineLocalDataSource {
 
     override suspend fun insertRoutine(
@@ -64,5 +65,17 @@ class RoutineLocalDataSourceImpl @Inject constructor(
 
     override suspend fun removeRoutineById(routineId: String) {
         return routineDao.removeRoutineById(routineId)
+    }
+
+    override suspend fun insertSharedRoutineDetail(
+        days: List<SharedRoutineDay>,
+        exercises: List<SharedRoutineExercise>,
+        sets: List<SharedRoutineExerciseSet>
+    ) {
+       sharedRoutineDao.insertSharedRoutineDetail(days, exercises, sets)
+    }
+
+    override suspend fun getSharedRoutineWithDaysByRoutineId(routineId: String): Flow<SharedRoutineWithDays> {
+        return sharedRoutineDao.getSharedRoutineWithDaysByRoutineId(routineId)
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSource.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface RoutineRemoteDataSource {
     fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>>
-    suspend fun getSharedRoutineDays(routineId: String): Flow<List<SharedRoutineDay>>
-    suspend fun getSharedRoutineExercises(routineId: String, dayId: String): Flow<List<SharedRoutineExercise>>
-    suspend fun getSharedRoutineExerciseSets(routineId: String, dayId: String, exerciseId: String): Flow<List<SharedRoutineExerciseSet>>
+    suspend fun getSharedRoutineDays(routineId: String): List<SharedRoutineDay>
+    suspend fun getSharedRoutineExercises(routineId: String, dayId: String): List<SharedRoutineExercise>
+    suspend fun getSharedRoutineExerciseSets(routineId: String, dayId: String, exerciseId: String): List<SharedRoutineExerciseSet>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSource.kt
@@ -2,8 +2,14 @@ package com.lateinit.rightweight.data.datasource
 
 import androidx.paging.PagingData
 import com.lateinit.rightweight.data.database.entity.SharedRoutine
+import com.lateinit.rightweight.data.database.entity.SharedRoutineDay
+import com.lateinit.rightweight.data.database.entity.SharedRoutineExercise
+import com.lateinit.rightweight.data.database.entity.SharedRoutineExerciseSet
 import kotlinx.coroutines.flow.Flow
 
 interface RoutineRemoteDataSource {
     fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>>
+    suspend fun getSharedRoutineDays(routineId: String): Flow<List<SharedRoutineDay>>
+    suspend fun getSharedRoutineExercises(routineId: String, dayId: String): Flow<List<SharedRoutineExercise>>
+    suspend fun getSharedRoutineExerciseSets(routineId: String, dayId: String, exerciseId: String): Flow<List<SharedRoutineExerciseSet>>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
@@ -6,7 +6,15 @@ import androidx.paging.PagingConfig
 import com.lateinit.rightweight.data.RoutineApiService
 import com.lateinit.rightweight.data.database.AppDatabase
 import com.lateinit.rightweight.data.database.AppSharedPreferences
+import com.lateinit.rightweight.data.database.entity.SharedRoutineDay
+import com.lateinit.rightweight.data.database.entity.SharedRoutineExercise
+import com.lateinit.rightweight.data.database.entity.SharedRoutineExerciseSet
 import com.lateinit.rightweight.data.database.mediator.SharedRoutineRemoteMediator
+import com.lateinit.rightweight.util.toSharedRoutineDay
+import com.lateinit.rightweight.util.toSharedRoutineExercise
+import com.lateinit.rightweight.util.toSharedRoutineExerciseSet
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class RoutineRemoteDataSourceImpl @Inject constructor(
@@ -25,4 +33,41 @@ class RoutineRemoteDataSourceImpl @Inject constructor(
     ) {
         db.sharedRoutineDao().getAllSharedRoutinesByPaging()
     }.flow
+
+    override suspend fun getSharedRoutineDays(routineId: String): Flow<List<SharedRoutineDay>> {
+        return flow{
+            val sharedRoutineDays = mutableListOf<SharedRoutineDay>()
+            api.getSharedRoutineDays(routineId)?.documents?.forEach(){
+                sharedRoutineDays.add(it.toSharedRoutineDay())
+            }
+            emit(sharedRoutineDays.toList())
+        }
+    }
+
+    override suspend fun getSharedRoutineExercises(
+        routineId: String,
+        dayId: String
+    ): Flow<List<SharedRoutineExercise>> {
+        return flow{
+            val sharedRoutineExercises = mutableListOf<SharedRoutineExercise>()
+            api.getSharedRoutineExercises(routineId, dayId)?.documents?.forEach(){
+                sharedRoutineExercises.add(it.toSharedRoutineExercise())
+            }
+            emit(sharedRoutineExercises.toList())
+        }
+    }
+
+    override suspend fun getSharedRoutineExerciseSets(
+        routineId: String,
+        dayId: String,
+        exerciseId: String
+    ): Flow<List<SharedRoutineExerciseSet>> {
+        return flow{
+            val sharedRoutineExerciseSets = mutableListOf<SharedRoutineExerciseSet>()
+            api.getSharedRoutineExerciseSets(routineId, dayId, exerciseId)?.documents?.forEach(){
+                sharedRoutineExerciseSets.add(it.toSharedRoutineExerciseSet())
+            }
+            emit(sharedRoutineExerciseSets.toList())
+        }
+    }
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/RoutineRemoteDataSourceImpl.kt
@@ -34,40 +34,34 @@ class RoutineRemoteDataSourceImpl @Inject constructor(
         db.sharedRoutineDao().getAllSharedRoutinesByPaging()
     }.flow
 
-    override suspend fun getSharedRoutineDays(routineId: String): Flow<List<SharedRoutineDay>> {
-        return flow{
-            val sharedRoutineDays = mutableListOf<SharedRoutineDay>()
-            api.getSharedRoutineDays(routineId)?.documents?.forEach(){
-                sharedRoutineDays.add(it.toSharedRoutineDay())
-            }
-            emit(sharedRoutineDays.toList())
+    override suspend fun getSharedRoutineDays(routineId: String): List<SharedRoutineDay> {
+        val sharedRoutineDays = mutableListOf<SharedRoutineDay>()
+        api.getSharedRoutineDays(routineId)?.documents?.forEach(){
+            sharedRoutineDays.add(it.toSharedRoutineDay())
         }
+        return sharedRoutineDays.toList()
     }
 
     override suspend fun getSharedRoutineExercises(
         routineId: String,
         dayId: String
-    ): Flow<List<SharedRoutineExercise>> {
-        return flow{
-            val sharedRoutineExercises = mutableListOf<SharedRoutineExercise>()
-            api.getSharedRoutineExercises(routineId, dayId)?.documents?.forEach(){
-                sharedRoutineExercises.add(it.toSharedRoutineExercise())
-            }
-            emit(sharedRoutineExercises.toList())
+    ): List<SharedRoutineExercise> {
+        val sharedRoutineExercises = mutableListOf<SharedRoutineExercise>()
+        api.getSharedRoutineExercises(routineId, dayId)?.documents?.forEach(){
+            sharedRoutineExercises.add(it.toSharedRoutineExercise())
         }
+        return sharedRoutineExercises.toList()
     }
 
     override suspend fun getSharedRoutineExerciseSets(
         routineId: String,
         dayId: String,
         exerciseId: String
-    ): Flow<List<SharedRoutineExerciseSet>> {
-        return flow{
-            val sharedRoutineExerciseSets = mutableListOf<SharedRoutineExerciseSet>()
-            api.getSharedRoutineExerciseSets(routineId, dayId, exerciseId)?.documents?.forEach(){
-                sharedRoutineExerciseSets.add(it.toSharedRoutineExerciseSet())
-            }
-            emit(sharedRoutineExerciseSets.toList())
+    ): List<SharedRoutineExerciseSet> {
+        val sharedRoutineExerciseSets = mutableListOf<SharedRoutineExerciseSet>()
+        api.getSharedRoutineExerciseSets(routineId, dayId, exerciseId)?.documents?.forEach(){
+            sharedRoutineExerciseSets.add(it.toSharedRoutineExerciseSet())
         }
+        return sharedRoutineExerciseSets.toList()
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/model/Documents.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/model/Documents.kt
@@ -1,7 +1,7 @@
 package com.lateinit.rightweight.data.model
 
-data class DocumentResponse<T>(val document: DetailResponse<T>)
+data class DocumentResponse<T>(val document: DetailResponse<T>?)
 
-data class DocumentsResponse<T>(val documents: List<DetailResponse<T>>)
+data class DocumentsResponse<T>(val documents: List<DetailResponse<T>>?)
 
 data class DetailResponse<T> (val name: String, val fields: T)

--- a/app/src/main/java/com/lateinit/rightweight/data/model/Documents.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/model/Documents.kt
@@ -2,4 +2,6 @@ package com.lateinit.rightweight.data.model
 
 data class DocumentResponse<T>(val document: DetailResponse<T>)
 
+data class DocumentsResponse<T>(val documents: List<DetailResponse<T>>)
+
 data class DetailResponse<T> (val name: String, val fields: T)

--- a/app/src/main/java/com/lateinit/rightweight/data/model/Documents.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/model/Documents.kt
@@ -6,5 +6,3 @@ data class DocumentsResponse<T>(val documents: List<DetailResponse<T>>?)
 
 data class DetailResponse<T> (val name: String, val fields: T)
 
-data class DocumentsListResponse<T> (val documents: List<DetailResponse<T>>)
-

--- a/app/src/main/java/com/lateinit/rightweight/data/remote/model/RemoteData.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/remote/model/RemoteData.kt
@@ -26,3 +26,32 @@ data class SharedRoutineField(
     @field:SerializedName("shared_count")
     val sharedCount: IntValue? = null,
 ): RemoteData()
+
+data class SharedRoutineDayField(
+    @field:SerializedName("routine_id")
+    val routine_id: StringValue? = null,
+    @field:SerializedName("order")
+    val order: IntValue? = null,
+): RemoteData()
+
+data class SharedRoutineExerciseField(
+    @field:SerializedName("part_type")
+    val partType: StringValue? = null,
+    @field:SerializedName("day_id")
+    val dayId: StringValue? = null,
+    @field:SerializedName("order")
+    val order: IntValue? = null,
+    @field:SerializedName("title")
+    val title: StringValue? = null,
+): RemoteData()
+
+data class SharedRoutineExerciseSetField(
+    @field:SerializedName("exercise_id")
+    val exerciseId: StringValue? = null,
+    @field:SerializedName("order")
+    val order: IntValue? = null,
+    @field:SerializedName("weight")
+    val weight: StringValue? = null,
+    @field:SerializedName("count")
+    val count: StringValue? = null,
+): RemoteData()

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
@@ -8,4 +8,5 @@ import kotlinx.coroutines.flow.Flow
 interface SharedRoutineRepository {
     suspend fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>>
     suspend fun getSharedRoutineDetail(routineId: String): Flow<SharedRoutineWithDays>
+    suspend fun requestSharedRoutineDetail(routineId: String)
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
@@ -10,7 +10,7 @@ import com.lateinit.rightweight.data.database.intermediate.SharedRoutineWithDays
 import kotlinx.coroutines.flow.Flow
 
 interface SharedRoutineRepository {
-    suspend fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>>
+    fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>>
     suspend fun shareRoutine(userId: String, routineId: String, routine: Routine)
     suspend fun shareDay(routineId: String, dayId: String, dayField: DayField)
     suspend fun shareExercise(

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
@@ -7,9 +7,5 @@ import kotlinx.coroutines.flow.Flow
 
 interface SharedRoutineRepository {
     suspend fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>>
-//    suspend fun getSharedRoutineDays(routineId: String): Flow<List<SharedRoutineDay>>
-//    suspend fun getSharedRoutineExercises(routineId: String, dayId: String): Flow<List<SharedRoutineExercise>>
-//    suspend fun getSharedRoutineExerciseSets(routineId: String, dayId: String, exerciseId: String): Flow<List<SharedRoutineExerciseSet>>
-
     suspend fun getSharedRoutineDetail(routineId: String): Flow<SharedRoutineWithDays>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
@@ -2,8 +2,14 @@ package com.lateinit.rightweight.data.repository
 
 import androidx.paging.PagingData
 import com.lateinit.rightweight.data.database.entity.SharedRoutine
+import com.lateinit.rightweight.data.database.entity.SharedRoutineDay
+import com.lateinit.rightweight.data.database.entity.SharedRoutineExercise
+import com.lateinit.rightweight.data.database.entity.SharedRoutineExerciseSet
 import kotlinx.coroutines.flow.Flow
 
 interface SharedRoutineRepository {
     suspend fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>>
+    suspend fun getSharedRoutineDays(routineId: String): Flow<List<SharedRoutineDay>>
+    suspend fun getSharedRoutineExercises(routineId: String, dayId: String): Flow<List<SharedRoutineExercise>>
+    suspend fun getSharedRoutineExerciseSets(routineId: String, dayId: String, exerciseId: String): Flow<List<SharedRoutineExerciseSet>>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepository.kt
@@ -2,14 +2,14 @@ package com.lateinit.rightweight.data.repository
 
 import androidx.paging.PagingData
 import com.lateinit.rightweight.data.database.entity.SharedRoutine
-import com.lateinit.rightweight.data.database.entity.SharedRoutineDay
-import com.lateinit.rightweight.data.database.entity.SharedRoutineExercise
-import com.lateinit.rightweight.data.database.entity.SharedRoutineExerciseSet
+import com.lateinit.rightweight.data.database.intermediate.SharedRoutineWithDays
 import kotlinx.coroutines.flow.Flow
 
 interface SharedRoutineRepository {
     suspend fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>>
-    suspend fun getSharedRoutineDays(routineId: String): Flow<List<SharedRoutineDay>>
-    suspend fun getSharedRoutineExercises(routineId: String, dayId: String): Flow<List<SharedRoutineExercise>>
-    suspend fun getSharedRoutineExerciseSets(routineId: String, dayId: String, exerciseId: String): Flow<List<SharedRoutineExerciseSet>>
+//    suspend fun getSharedRoutineDays(routineId: String): Flow<List<SharedRoutineDay>>
+//    suspend fun getSharedRoutineExercises(routineId: String, dayId: String): Flow<List<SharedRoutineExercise>>
+//    suspend fun getSharedRoutineExerciseSets(routineId: String, dayId: String, exerciseId: String): Flow<List<SharedRoutineExerciseSet>>
+
+    suspend fun getSharedRoutineDetail(routineId: String): Flow<SharedRoutineWithDays>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
@@ -1,11 +1,13 @@
 package com.lateinit.rightweight.data.repository
 
+import android.util.Log
 import androidx.paging.PagingData
 import com.lateinit.rightweight.data.database.entity.SharedRoutine
 import com.lateinit.rightweight.data.database.intermediate.SharedRoutineWithDays
 import com.lateinit.rightweight.data.datasource.RoutineLocalDataSource
 import com.lateinit.rightweight.data.datasource.RoutineRemoteDataSource
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
 class SharedRoutineRepositoryImpl @Inject constructor(
@@ -17,9 +19,10 @@ class SharedRoutineRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getSharedRoutineDetail(routineId: String): Flow<SharedRoutineWithDays> {
-        if(routineLocalDataSource.getDaysByRoutineId(routineId).isEmpty()){
-            return routineLocalDataSource.getSharedRoutineWithDaysByRoutineId(routineId)
-        }
+        return routineLocalDataSource.getSharedRoutineWithDaysByRoutineId(routineId)
+    }
+
+    override suspend fun requestSharedRoutineDetail(routineId: String) {
         routineRemoteDataSource.getSharedRoutineDays(routineId).collect() { sharedRoutineDays ->
             sharedRoutineDays.forEach() { sharedRoutineDay ->
                 routineRemoteDataSource.getSharedRoutineExercises(routineId, sharedRoutineDay.dayId)
@@ -36,7 +39,6 @@ class SharedRoutineRepositoryImpl @Inject constructor(
                     }
             }
         }
-        return routineLocalDataSource.getSharedRoutineWithDaysByRoutineId(routineId)
     }
 
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
@@ -2,6 +2,9 @@ package com.lateinit.rightweight.data.repository
 
 import androidx.paging.PagingData
 import com.lateinit.rightweight.data.database.entity.SharedRoutine
+import com.lateinit.rightweight.data.database.entity.SharedRoutineDay
+import com.lateinit.rightweight.data.database.entity.SharedRoutineExercise
+import com.lateinit.rightweight.data.database.entity.SharedRoutineExerciseSet
 import com.lateinit.rightweight.data.datasource.RoutineRemoteDataSource
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -11,5 +14,24 @@ class SharedRoutineRepositoryImpl @Inject constructor(
 ): SharedRoutineRepository {
     override suspend fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>> {
         return routineRemoteDataSource.getSharedRoutinesByPaging()
+    }
+
+    override suspend fun getSharedRoutineDays(routineId: String): Flow<List<SharedRoutineDay>> {
+        return routineRemoteDataSource.getSharedRoutineDays(routineId)
+    }
+
+    override suspend fun getSharedRoutineExercises(
+        routineId: String,
+        dayId: String
+    ): Flow<List<SharedRoutineExercise>> {
+        return routineRemoteDataSource.getSharedRoutineExercises(routineId, dayId)
+    }
+
+    override suspend fun getSharedRoutineExerciseSets(
+        routineId: String,
+        dayId: String,
+        exerciseId: String
+    ): Flow<List<SharedRoutineExerciseSet>> {
+        return routineRemoteDataSource.getSharedRoutineExerciseSets(routineId, dayId, exerciseId)
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
@@ -1,37 +1,62 @@
 package com.lateinit.rightweight.data.repository
 
+import android.util.Log
 import androidx.paging.PagingData
 import com.lateinit.rightweight.data.database.entity.SharedRoutine
-import com.lateinit.rightweight.data.database.entity.SharedRoutineDay
-import com.lateinit.rightweight.data.database.entity.SharedRoutineExercise
-import com.lateinit.rightweight.data.database.entity.SharedRoutineExerciseSet
+import com.lateinit.rightweight.data.database.intermediate.RoutineWithDays
+import com.lateinit.rightweight.data.database.intermediate.SharedRoutineDayWithExercises
+import com.lateinit.rightweight.data.database.intermediate.SharedRoutineWithDays
+import com.lateinit.rightweight.data.datasource.RoutineLocalDataSource
 import com.lateinit.rightweight.data.datasource.RoutineRemoteDataSource
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class SharedRoutineRepositoryImpl @Inject constructor(
-    private val routineRemoteDataSource: RoutineRemoteDataSource
-): SharedRoutineRepository {
+    private val routineRemoteDataSource: RoutineRemoteDataSource,
+    private val routineLocalDataSource: RoutineLocalDataSource
+) : SharedRoutineRepository {
     override suspend fun getSharedRoutinesByPaging(): Flow<PagingData<SharedRoutine>> {
         return routineRemoteDataSource.getSharedRoutinesByPaging()
     }
 
-    override suspend fun getSharedRoutineDays(routineId: String): Flow<List<SharedRoutineDay>> {
-        return routineRemoteDataSource.getSharedRoutineDays(routineId)
+    override suspend fun getSharedRoutineDetail(routineId: String): Flow<SharedRoutineWithDays> {
+        routineRemoteDataSource.getSharedRoutineDays(routineId).collect() { sharedRoutineDays ->
+            sharedRoutineDays.forEach() { sharedRoutineDay ->
+                routineRemoteDataSource.getSharedRoutineExercises(routineId, sharedRoutineDay.dayId)
+                    .collect() { sharedRoutineExercises ->
+                        sharedRoutineExercises.forEach() { sharedRoutineExercise ->
+                            routineRemoteDataSource.getSharedRoutineExerciseSets(
+                                routineId,
+                                sharedRoutineExercise.dayId,
+                                sharedRoutineExercise.exerciseId
+                            ).collect() { sharedRoutineExerciseSets ->
+                                routineLocalDataSource.insertSharedRoutineDetail(sharedRoutineDays, sharedRoutineExercises, sharedRoutineExerciseSets)
+                            }
+                        }
+                    }
+            }
+        }
+        return routineLocalDataSource.getSharedRoutineWithDaysByRoutineId(routineId)
     }
 
-    override suspend fun getSharedRoutineExercises(
-        routineId: String,
-        dayId: String
-    ): Flow<List<SharedRoutineExercise>> {
-        return routineRemoteDataSource.getSharedRoutineExercises(routineId, dayId)
-    }
+//    override suspend fun getSharedRoutineDays(routineId: String): Flow<List<SharedRoutineDay>> {
+//        return routineRemoteDataSource.getSharedRoutineDays(routineId)
+//    }
 
-    override suspend fun getSharedRoutineExerciseSets(
-        routineId: String,
-        dayId: String,
-        exerciseId: String
-    ): Flow<List<SharedRoutineExerciseSet>> {
-        return routineRemoteDataSource.getSharedRoutineExerciseSets(routineId, dayId, exerciseId)
-    }
+//    override suspend fun getSharedRoutineExercises(
+//        routineId: String,
+//        dayId: String
+//    ): Flow<List<SharedRoutineExercise>> {
+//        return routineRemoteDataSource.getSharedRoutineExercises(routineId, dayId)
+//    }
+//
+//    override suspend fun getSharedRoutineExerciseSets(
+//        routineId: String,
+//        dayId: String,
+//        exerciseId: String
+//    ): Flow<List<SharedRoutineExerciseSet>> {
+//        return routineRemoteDataSource.getSharedRoutineExerciseSets(routineId, dayId, exerciseId)
+//    }
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/SharedRoutineRepositoryImpl.kt
@@ -1,16 +1,11 @@
 package com.lateinit.rightweight.data.repository
 
-import android.util.Log
 import androidx.paging.PagingData
 import com.lateinit.rightweight.data.database.entity.SharedRoutine
-import com.lateinit.rightweight.data.database.intermediate.RoutineWithDays
-import com.lateinit.rightweight.data.database.intermediate.SharedRoutineDayWithExercises
 import com.lateinit.rightweight.data.database.intermediate.SharedRoutineWithDays
 import com.lateinit.rightweight.data.datasource.RoutineLocalDataSource
 import com.lateinit.rightweight.data.datasource.RoutineRemoteDataSource
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class SharedRoutineRepositoryImpl @Inject constructor(
@@ -22,6 +17,9 @@ class SharedRoutineRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getSharedRoutineDetail(routineId: String): Flow<SharedRoutineWithDays> {
+        if(routineLocalDataSource.getDaysByRoutineId(routineId).isEmpty()){
+            return routineLocalDataSource.getSharedRoutineWithDaysByRoutineId(routineId)
+        }
         routineRemoteDataSource.getSharedRoutineDays(routineId).collect() { sharedRoutineDays ->
             sharedRoutineDays.forEach() { sharedRoutineDay ->
                 routineRemoteDataSource.getSharedRoutineExercises(routineId, sharedRoutineDay.dayId)
@@ -41,22 +39,4 @@ class SharedRoutineRepositoryImpl @Inject constructor(
         return routineLocalDataSource.getSharedRoutineWithDaysByRoutineId(routineId)
     }
 
-//    override suspend fun getSharedRoutineDays(routineId: String): Flow<List<SharedRoutineDay>> {
-//        return routineRemoteDataSource.getSharedRoutineDays(routineId)
-//    }
-
-//    override suspend fun getSharedRoutineExercises(
-//        routineId: String,
-//        dayId: String
-//    ): Flow<List<SharedRoutineExercise>> {
-//        return routineRemoteDataSource.getSharedRoutineExercises(routineId, dayId)
-//    }
-//
-//    override suspend fun getSharedRoutineExerciseSets(
-//        routineId: String,
-//        dayId: String,
-//        exerciseId: String
-//    ): Flow<List<SharedRoutineExerciseSet>> {
-//        return routineRemoteDataSource.getSharedRoutineExerciseSets(routineId, dayId, exerciseId)
-//    }
 }

--- a/app/src/main/java/com/lateinit/rightweight/di/DataSourceModule.kt
+++ b/app/src/main/java/com/lateinit/rightweight/di/DataSourceModule.kt
@@ -6,6 +6,7 @@ import com.lateinit.rightweight.data.database.AppDatabase
 import com.lateinit.rightweight.data.database.AppSharedPreferences
 import com.lateinit.rightweight.data.database.dao.HistoryDao
 import com.lateinit.rightweight.data.database.dao.RoutineDao
+import com.lateinit.rightweight.data.database.dao.SharedRoutineDao
 import com.lateinit.rightweight.data.datasource.*
 import dagger.Module
 import dagger.Provides
@@ -27,8 +28,11 @@ class DataSourceModule {
 
     @Provides
     @Singleton
-    fun getRoutineLocalDataSource(routineDao: RoutineDao): RoutineLocalDataSource {
-        return RoutineLocalDataSourceImpl(routineDao)
+    fun getRoutineLocalDataSource(
+        routineDao: RoutineDao,
+        sharedRoutineDao: SharedRoutineDao
+    ): RoutineLocalDataSource {
+        return RoutineLocalDataSourceImpl(routineDao, sharedRoutineDao)
     }
 
     @Provides

--- a/app/src/main/java/com/lateinit/rightweight/di/DatabaseModule.kt
+++ b/app/src/main/java/com/lateinit/rightweight/di/DatabaseModule.kt
@@ -6,6 +6,7 @@ import com.lateinit.rightweight.data.database.AppDatabase
 import com.lateinit.rightweight.data.database.AppSharedPreferences
 import com.lateinit.rightweight.data.database.dao.HistoryDao
 import com.lateinit.rightweight.data.database.dao.RoutineDao
+import com.lateinit.rightweight.data.database.dao.SharedRoutineDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -33,6 +34,12 @@ class DatabaseModule {
     @Singleton
     fun getHistoryDao(appDatabase: AppDatabase): HistoryDao {
         return appDatabase.historyDao()
+    }
+
+    @Provides
+    @Singleton
+    fun getSharedRoutineDao(appDatabase: AppDatabase): SharedRoutineDao {
+        return appDatabase.sharedRoutineDao()
     }
 
     @Provides

--- a/app/src/main/java/com/lateinit/rightweight/di/RepositoryModule.kt
+++ b/app/src/main/java/com/lateinit/rightweight/di/RepositoryModule.kt
@@ -49,8 +49,9 @@ class RepositoryModule {
     @Provides
     @Singleton
     fun getSharedRoutineRepository(
-        routineRemoteDataSource: RoutineRemoteDataSource
+        routineRemoteDataSource: RoutineRemoteDataSource,
+        routineLocalDataSource: RoutineLocalDataSource
     ): SharedRoutineRepository {
-        return SharedRoutineRepositoryImpl(routineRemoteDataSource)
+        return SharedRoutineRepositoryImpl(routineRemoteDataSource, routineLocalDataSource)
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/ui/exercise/ExerciseFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/exercise/ExerciseFragment.kt
@@ -70,7 +70,7 @@ class ExerciseFragment : Fragment(), HistoryEventListener {
         renewTodayHistory()
 
         binding.buttonExerciseStartAndPause.setOnClickListener {
-            if (binding.isTimerRunning) {
+            if (binding.isTimerRunning == true) {
                 startTimerServiceWithMode(PAUSE)
             } else {
                 startTimerServiceWithMode(START)

--- a/app/src/main/java/com/lateinit/rightweight/ui/share/SharedRoutineFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/share/SharedRoutineFragment.kt
@@ -3,6 +3,7 @@ package com.lateinit.rightweight.ui.share
 import android.os.Bundle
 import android.util.Log
 import android.view.*
+import androidx.core.os.bundleOf
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
@@ -77,6 +78,7 @@ class SharedRoutineFragment : Fragment(), SharedRoutineClickHandler {
     }
 
     override fun gotoSharedRoutineDetailFragment(routineId: String) {
-        findNavController(this).navigate(R.id.action_navigation_shared_routine_to_navigation_shared_routine_detail)
+        val bundle = bundleOf("routineId" to routineId)
+        findNavController(this).navigate(R.id.action_navigation_shared_routine_to_navigation_shared_routine_detail, bundle)
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/ui/share/detail/SharedRoutineDetailFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/share/detail/SharedRoutineDetailFragment.kt
@@ -42,11 +42,14 @@ class SharedRoutineDetailFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        sharedRoutineDetailViewModel.getSharedRoutineDetail("07fd07ab-45c6-4479-881a-abe151a82456")
+        val routineId = arguments?.getString("routineId")
+        routineId?.let{
+            sharedRoutineDetailViewModel.getSharedRoutineDetail(routineId)
+        }
 
         setRoutineDayAdapter()
         setExerciseAdapter()
-        setDayUiModelsCollect()
+        setSharedRoutineDetailCollect()
     }
 
     private fun setRoutineDayAdapter() {
@@ -64,12 +67,13 @@ class SharedRoutineDetailFragment : Fragment() {
         binding.recyclerViewExercise.adapter = exerciseAdapter
     }
 
-    private fun setDayUiModelsCollect() {
+    private fun setSharedRoutineDetailCollect() {
         lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 sharedRoutineDetailViewModel.uiState.collect() { uiState ->
                     when (uiState) {
                         is LatestSharedRoutineDetailUiState.Success -> {
+                            binding.sharedRoutine = uiState.sharedRoutine
                             routineDayAdapter.submitList(uiState.dayUiModels)
                             setCurrentDayPositionObserve(uiState.dayUiModels)
                         }

--- a/app/src/main/java/com/lateinit/rightweight/ui/share/detail/SharedRoutineDetailFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/share/detail/SharedRoutineDetailFragment.kt
@@ -1,30 +1,94 @@
 package com.lateinit.rightweight.ui.share.detail
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
 import androidx.fragment.app.Fragment
-import androidx.navigation.findNavController
-import com.lateinit.rightweight.R
-import com.lateinit.rightweight.ui.home.HomeActivity
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.lateinit.rightweight.databinding.FragmentSharedRoutineDetailBinding
+import com.lateinit.rightweight.ui.model.DayUiModel
+import com.lateinit.rightweight.ui.routine.detail.DetailExerciseAdapter
+import com.lateinit.rightweight.ui.routine.editor.RoutineDayAdapter
+import com.lateinit.rightweight.ui.share.LatestSharedRoutineUiState
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class SharedRoutineDetailFragment : Fragment() {
+
+    private var _binding: FragmentSharedRoutineDetailBinding? = null
+    private val binding
+        get() = checkNotNull(_binding) { "binding was accessed outside of view lifecycle" }
+
+    val sharedRoutineDetailViewModel :SharedRoutineDetailViewModel by viewModels()
+
+    private lateinit var routineDayAdapter: RoutineDayAdapter
+    private lateinit var exerciseAdapter: DetailExerciseAdapter
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_shared_routine_detail, container, false)
+        _binding = FragmentSharedRoutineDetailBinding.inflate(inflater, container, false)
+
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val copyBtn = view.findViewById<Button>(R.id.copy)
 
-        copyBtn.setOnClickListener {
-            it.findNavController().navigateUp()
-            (requireActivity() as HomeActivity).navigateBottomNav(R.id.navigation_routine_management)
+        sharedRoutineDetailViewModel.getSharedRoutineDetail("07fd07ab-45c6-4479-881a-abe151a82456")
+
+        setRoutineDayAdapter()
+        setExerciseAdapter()
+        setDayUiModelsCollect()
+    }
+
+    private fun setRoutineDayAdapter() {
+        routineDayAdapter =
+            RoutineDayAdapter { position ->
+                sharedRoutineDetailViewModel.clickDay(position)
+            }
+        binding.recyclerViewDay.adapter = routineDayAdapter
+    }
+
+    private fun setExerciseAdapter() {
+        exerciseAdapter = DetailExerciseAdapter { position ->
+            sharedRoutineDetailViewModel.clickExercise(position)
+        }
+        binding.recyclerViewExercise.adapter = exerciseAdapter
+    }
+
+    private fun setDayUiModelsCollect() {
+        lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                sharedRoutineDetailViewModel.uiState.collect() { uiState ->
+                    when (uiState) {
+                        is LatestSharedRoutineDetailUiState.Success -> {
+                            routineDayAdapter.submitList(uiState.dayUiModels)
+                            setCurrentDayPositionObserve(uiState.dayUiModels)
+                        }
+                        is LatestSharedRoutineDetailUiState.Error -> Exception()
+                    }
+                }
+            }
         }
     }
+
+    private fun setCurrentDayPositionObserve(dayUiModels: List<DayUiModel>) {
+        sharedRoutineDetailViewModel.currentDayPosition.observe(viewLifecycleOwner) {
+            Log.d("dayUiModels", dayUiModels.toString())
+            if(dayUiModels.size > it){
+                val exercises = dayUiModels.get(it).exercises
+                exerciseAdapter.submitList(exercises)
+            }
+        }
+    }
+
+
 }

--- a/app/src/main/java/com/lateinit/rightweight/ui/share/detail/SharedRoutineDetailViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/share/detail/SharedRoutineDetailViewModel.kt
@@ -1,0 +1,76 @@
+package com.lateinit.rightweight.ui.share.detail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lateinit.rightweight.data.database.entity.SharedRoutineDay
+import com.lateinit.rightweight.data.database.entity.SharedRoutineExercise
+import com.lateinit.rightweight.data.database.entity.SharedRoutineExerciseSet
+import com.lateinit.rightweight.data.repository.SharedRoutineRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SharedRoutineDetailViewModel @Inject constructor(
+    private val sharedRoutineRepository: SharedRoutineRepository
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(
+        LatestSharedRoutineDetailUiState.Success(mutableMapOf(), mutableMapOf(), mutableMapOf())
+    )
+    val uiState: StateFlow<LatestSharedRoutineDetailUiState> = _uiState
+
+    fun getSharedRoutineDetail(routineId: String) {
+        viewModelScope.launch {
+            val sharedRoutineDaysMap = mutableMapOf<String, List<SharedRoutineDay>>()
+            val sharedRoutineExercisesMap = mutableMapOf<String, List<SharedRoutineExercise>>()
+            val sharedRoutineExerciseSetsMap =
+                mutableMapOf<String, List<SharedRoutineExerciseSet>>()
+
+            sharedRoutineRepository.getSharedRoutineDays(routineId)
+                .collect() { sharedRoutineDays ->
+                    sharedRoutineDaysMap.put(routineId, sharedRoutineDays)
+                    sharedRoutineDays.forEach() { sharedRoutineDay ->
+                        sharedRoutineRepository.getSharedRoutineExercises(
+                            routineId,
+                            sharedRoutineDay.dayId
+                        ).collect() { sharedRoutineExercises ->
+                            sharedRoutineExercisesMap.put(
+                                sharedRoutineDay.dayId,
+                                sharedRoutineExercises
+                            )
+                            sharedRoutineExercises.forEach() { sharedRoutineExercise ->
+                                sharedRoutineRepository.getSharedRoutineExerciseSets(
+                                    routineId,
+                                    sharedRoutineDay.dayId,
+                                    sharedRoutineExercise.exerciseId
+                                ).collect() { sharedRoutineExerciseSets ->
+                                    sharedRoutineExerciseSetsMap.put(
+                                        sharedRoutineExercise.exerciseId,
+                                        sharedRoutineExerciseSets
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    _uiState.value = LatestSharedRoutineDetailUiState.Success(
+                        sharedRoutineDaysMap,
+                        sharedRoutineExercisesMap,
+                        sharedRoutineExerciseSetsMap
+                    )
+                }
+        }
+    }
+
+}
+
+sealed class LatestSharedRoutineDetailUiState {
+    data class Success(
+        val sharedRoutineDays: Map<String, List<SharedRoutineDay>>,
+        val sharedRoutineExercises: Map<String, List<SharedRoutineExercise>>,
+        val sharedRoutineExerciseSets: Map<String, List<SharedRoutineExerciseSet>>
+    ) : LatestSharedRoutineDetailUiState()
+
+    data class Error(val exception: Throwable) : LatestSharedRoutineDetailUiState()
+}

--- a/app/src/main/java/com/lateinit/rightweight/ui/share/detail/SharedRoutineDetailViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/share/detail/SharedRoutineDetailViewModel.kt
@@ -1,14 +1,21 @@
 package com.lateinit.rightweight.ui.share.detail
 
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lateinit.rightweight.data.database.entity.SharedRoutineDay
 import com.lateinit.rightweight.data.database.entity.SharedRoutineExercise
 import com.lateinit.rightweight.data.database.entity.SharedRoutineExerciseSet
 import com.lateinit.rightweight.data.repository.SharedRoutineRepository
+import com.lateinit.rightweight.ui.model.DayUiModel
+import com.lateinit.rightweight.util.FIRST_DAY_POSITION
+import com.lateinit.rightweight.util.toDayUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -16,61 +23,65 @@ import javax.inject.Inject
 class SharedRoutineDetailViewModel @Inject constructor(
     private val sharedRoutineRepository: SharedRoutineRepository
 ) : ViewModel() {
+
     private val _uiState = MutableStateFlow(
-        LatestSharedRoutineDetailUiState.Success(mutableMapOf(), mutableMapOf(), mutableMapOf())
+        LatestSharedRoutineDetailUiState.Success(mutableListOf())
     )
     val uiState: StateFlow<LatestSharedRoutineDetailUiState> = _uiState
 
+    private val _currentDayPosition = MutableLiveData<Int>()
+    val currentDayPosition: LiveData<Int> = _currentDayPosition
+
     fun getSharedRoutineDetail(routineId: String) {
         viewModelScope.launch {
-            val sharedRoutineDaysMap = mutableMapOf<String, List<SharedRoutineDay>>()
-            val sharedRoutineExercisesMap = mutableMapOf<String, List<SharedRoutineExercise>>()
-            val sharedRoutineExerciseSetsMap =
-                mutableMapOf<String, List<SharedRoutineExerciseSet>>()
+            sharedRoutineRepository.getSharedRoutineDetail(routineId).collect(){ sharedRoutineWithDays ->
+                _uiState.value = LatestSharedRoutineDetailUiState.Success(sharedRoutineWithDays.days.mapIndexed { index, sharedRoutineWithDay ->
+                    sharedRoutineWithDay.day.toDayUiModel(index, sharedRoutineWithDay.exercises)
+                })
+                _currentDayPosition.value = FIRST_DAY_POSITION
+            }
 
-            sharedRoutineRepository.getSharedRoutineDays(routineId)
-                .collect() { sharedRoutineDays ->
-                    sharedRoutineDaysMap.put(routineId, sharedRoutineDays)
-                    sharedRoutineDays.forEach() { sharedRoutineDay ->
-                        sharedRoutineRepository.getSharedRoutineExercises(
-                            routineId,
-                            sharedRoutineDay.dayId
-                        ).collect() { sharedRoutineExercises ->
-                            sharedRoutineExercisesMap.put(
-                                sharedRoutineDay.dayId,
-                                sharedRoutineExercises
-                            )
-                            sharedRoutineExercises.forEach() { sharedRoutineExercise ->
-                                sharedRoutineRepository.getSharedRoutineExerciseSets(
-                                    routineId,
-                                    sharedRoutineDay.dayId,
-                                    sharedRoutineExercise.exerciseId
-                                ).collect() { sharedRoutineExerciseSets ->
-                                    sharedRoutineExerciseSetsMap.put(
-                                        sharedRoutineExercise.exerciseId,
-                                        sharedRoutineExerciseSets
-                                    )
-                                }
-                            }
-                        }
-                    }
-                    _uiState.value = LatestSharedRoutineDetailUiState.Success(
-                        sharedRoutineDaysMap,
-                        sharedRoutineExercisesMap,
-                        sharedRoutineExerciseSetsMap
-                    )
-                }
         }
+    }
+
+    fun clickDay(dayPosition: Int) {
+        if (_currentDayPosition.value == dayPosition) return
+
+        val originDayUiModels = _uiState.value.dayUiModels.toMutableList()
+        val lastSelectedPosition = _currentDayPosition.value ?: return
+
+        originDayUiModels[lastSelectedPosition] =
+            originDayUiModels[lastSelectedPosition].copy(selected = false)
+        originDayUiModels[dayPosition] = originDayUiModels[dayPosition].copy(selected = true)
+
+        _currentDayPosition.value = dayPosition
+        _uiState.value = LatestSharedRoutineDetailUiState.Success(originDayUiModels)
+    }
+
+    fun clickExercise(exercisePosition: Int) {
+        val nowDayPosition = _currentDayPosition.value ?: return
+        val originDayUiModels = _uiState.value.dayUiModels.toMutableList()
+        val originExerciseUiModels = originDayUiModels[nowDayPosition].exercises.toMutableList()
+        val exerciseUiModel = originExerciseUiModels[exercisePosition]
+
+        originExerciseUiModels[exercisePosition] = exerciseUiModel.copy(
+            expanded = exerciseUiModel.expanded.not()
+        )
+
+        originDayUiModels[nowDayPosition] =
+            originDayUiModels[nowDayPosition].copy(exercises = originExerciseUiModels)
+
+        _currentDayPosition.value = _currentDayPosition.value
+        _uiState.value = LatestSharedRoutineDetailUiState.Success(originDayUiModels)
     }
 
 }
 
 sealed class LatestSharedRoutineDetailUiState {
     data class Success(
-        val sharedRoutineDays: Map<String, List<SharedRoutineDay>>,
-        val sharedRoutineExercises: Map<String, List<SharedRoutineExercise>>,
-        val sharedRoutineExerciseSets: Map<String, List<SharedRoutineExerciseSet>>
+        val dayUiModels: List<DayUiModel>
     ) : LatestSharedRoutineDetailUiState()
 
     data class Error(val exception: Throwable) : LatestSharedRoutineDetailUiState()
 }
+

--- a/app/src/main/java/com/lateinit/rightweight/ui/share/detail/SharedRoutineDetailViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/share/detail/SharedRoutineDetailViewModel.kt
@@ -37,6 +37,11 @@ class SharedRoutineDetailViewModel @Inject constructor(
         viewModelScope.launch {
             sharedRoutineRepository.getSharedRoutineDetail(routineId)
                 .collect() { sharedRoutineWithDays ->
+
+                    if(sharedRoutineWithDays.days.isEmpty()){
+                        sharedRoutineRepository.requestSharedRoutineDetail(routineId)
+                    }
+
                     _uiState.value = LatestSharedRoutineDetailUiState.Success(
                         sharedRoutineWithDays.routine,
                         sharedRoutineWithDays.days.mapIndexed { index, sharedRoutineWithDay ->

--- a/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
+++ b/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
@@ -1,14 +1,16 @@
 package com.lateinit.rightweight.util
 
-import com.lateinit.rightweight.data.database.entity.Day
-import com.lateinit.rightweight.data.database.entity.Exercise
-import com.lateinit.rightweight.data.database.entity.ExerciseSet
-import com.lateinit.rightweight.data.database.entity.HistorySet
-import com.lateinit.rightweight.data.database.entity.SharedRoutine
+import androidx.room.ColumnInfo
+import androidx.room.PrimaryKey
+import com.lateinit.rightweight.data.ExercisePartType
+import com.lateinit.rightweight.data.database.entity.*
 import com.lateinit.rightweight.data.database.intermediate.ExerciseWithSets
 import com.lateinit.rightweight.data.database.intermediate.HistoryExerciseWithHistorySets
 import com.lateinit.rightweight.data.database.intermediate.HistoryWithHistoryExercises
 import com.lateinit.rightweight.data.model.DetailResponse
+import com.lateinit.rightweight.data.remote.model.SharedRoutineDayField
+import com.lateinit.rightweight.data.remote.model.SharedRoutineExerciseField
+import com.lateinit.rightweight.data.remote.model.SharedRoutineExerciseSetField
 import com.lateinit.rightweight.data.remote.model.SharedRoutineField
 import com.lateinit.rightweight.ui.model.DayUiModel
 import com.lateinit.rightweight.ui.model.ExerciseSetUiModel
@@ -115,7 +117,7 @@ fun ExerciseSetUiModel.toExerciseSet(): ExerciseSet {
 fun DetailResponse<SharedRoutineField>.toSharedRoutine(): SharedRoutine {
     val splitedName = name.split("/")
     val refinedModifiedDateString = fields.modifiedDate?.value?.replace("T", " ")?.replace("Z", "")
-    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
     val modifiedDate = LocalDateTime.parse(refinedModifiedDateString, formatter)
     return SharedRoutine(
         routineId = splitedName.last(),
@@ -123,5 +125,37 @@ fun DetailResponse<SharedRoutineField>.toSharedRoutine(): SharedRoutine {
         author = fields.author?.value.toString(),
         description = fields.description?.value.toString(),
         modifiedDate = modifiedDate
+    )
+}
+
+fun DetailResponse<SharedRoutineDayField>.toSharedRoutineDay(): SharedRoutineDay {
+    val splitedName = name.split("/")
+    return SharedRoutineDay(
+        routineId = fields.routine_id?.value.toString(),
+        dayId = splitedName.last(),
+        order = fields.order?.value.toString().toInt()
+    )
+}
+
+fun DetailResponse<SharedRoutineExerciseField>.toSharedRoutineExercise(): SharedRoutineExercise {
+    val splitedName = name.split("/")
+    return SharedRoutineExercise(
+        dayId = fields.dayId?.value.toString(),
+        exerciseId = splitedName.last(),
+        title = fields.title?.value.toString(),
+        order = fields.order?.value.toString().toInt(),
+        part = ExercisePartType.CHEST
+        //part =  ExercisePartType.valueOf(fields.partType?.value.toString())
+    )
+}
+
+fun DetailResponse<SharedRoutineExerciseSetField>.toSharedRoutineExerciseSet(): SharedRoutineExerciseSet {
+    val splitedName = name.split("/")
+    return SharedRoutineExerciseSet(
+        exerciseId = fields.exerciseId?.value.toString(),
+        setId = splitedName.last(),
+        weight = fields.weight?.value.toString(),
+        count = fields.count?.value.toString(),
+        order = fields.order?.value.toString().toInt()
     )
 }

--- a/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
+++ b/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
@@ -1,21 +1,17 @@
 package com.lateinit.rightweight.util
 
-import androidx.room.ColumnInfo
-import androidx.room.PrimaryKey
 import com.lateinit.rightweight.data.ExercisePartType
 import com.lateinit.rightweight.data.database.entity.*
-import com.lateinit.rightweight.data.database.intermediate.*
+import com.lateinit.rightweight.data.database.intermediate.ExerciseWithSets
+import com.lateinit.rightweight.data.database.intermediate.HistoryExerciseWithHistorySets
+import com.lateinit.rightweight.data.database.intermediate.HistoryWithHistoryExercises
+import com.lateinit.rightweight.data.database.intermediate.SharedRoutineExerciseWithExerciseSets
 import com.lateinit.rightweight.data.model.DetailResponse
 import com.lateinit.rightweight.data.remote.model.SharedRoutineDayField
 import com.lateinit.rightweight.data.remote.model.SharedRoutineExerciseField
 import com.lateinit.rightweight.data.remote.model.SharedRoutineExerciseSetField
 import com.lateinit.rightweight.data.remote.model.SharedRoutineField
-import com.lateinit.rightweight.ui.model.DayUiModel
-import com.lateinit.rightweight.ui.model.ExerciseSetUiModel
-import com.lateinit.rightweight.ui.model.ExerciseUiModel
-import com.lateinit.rightweight.ui.model.HistoryExerciseSetUiModel
-import com.lateinit.rightweight.ui.model.HistoryExerciseUiModel
-import com.lateinit.rightweight.ui.model.HistoryUiModel
+import com.lateinit.rightweight.ui.model.*
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -158,7 +154,10 @@ fun DetailResponse<SharedRoutineExerciseSetField>.toSharedRoutineExerciseSet(): 
     )
 }
 
-fun SharedRoutineDay.toDayUiModel(index: Int, exercises: List<SharedRoutineExerciseWithExerciseSets>):DayUiModel{
+fun SharedRoutineDay.toDayUiModel(
+    index: Int,
+    exercises: List<SharedRoutineExerciseWithExerciseSets>
+): DayUiModel {
     return DayUiModel(
         dayId = dayId,
         routineId = routineId,
@@ -168,7 +167,7 @@ fun SharedRoutineDay.toDayUiModel(index: Int, exercises: List<SharedRoutineExerc
     )
 }
 
-fun SharedRoutineExerciseWithExerciseSets.toExerciseUiModel():ExerciseUiModel{
+fun SharedRoutineExerciseWithExerciseSets.toExerciseUiModel(): ExerciseUiModel {
     return ExerciseUiModel(
         exerciseId = exercise.exerciseId,
         dayId = exercise.dayId,

--- a/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
+++ b/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
@@ -4,9 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.PrimaryKey
 import com.lateinit.rightweight.data.ExercisePartType
 import com.lateinit.rightweight.data.database.entity.*
-import com.lateinit.rightweight.data.database.intermediate.ExerciseWithSets
-import com.lateinit.rightweight.data.database.intermediate.HistoryExerciseWithHistorySets
-import com.lateinit.rightweight.data.database.intermediate.HistoryWithHistoryExercises
+import com.lateinit.rightweight.data.database.intermediate.*
 import com.lateinit.rightweight.data.model.DetailResponse
 import com.lateinit.rightweight.data.remote.model.SharedRoutineDayField
 import com.lateinit.rightweight.data.remote.model.SharedRoutineExerciseField
@@ -157,5 +155,36 @@ fun DetailResponse<SharedRoutineExerciseSetField>.toSharedRoutineExerciseSet(): 
         weight = fields.weight?.value.toString(),
         count = fields.count?.value.toString(),
         order = fields.order?.value.toString().toInt()
+    )
+}
+
+fun SharedRoutineDay.toDayUiModel(index: Int, exercises: List<SharedRoutineExerciseWithExerciseSets>):DayUiModel{
+    return DayUiModel(
+        dayId = dayId,
+        routineId = routineId,
+        order = order,
+        selected = index == FIRST_DAY_POSITION,
+        exercises = exercises.map { it.toExerciseUiModel() }
+    )
+}
+
+fun SharedRoutineExerciseWithExerciseSets.toExerciseUiModel():ExerciseUiModel{
+    return ExerciseUiModel(
+        exerciseId = exercise.exerciseId,
+        dayId = exercise.dayId,
+        title = exercise.title,
+        order = exercise.order,
+        part = exercise.part,
+        exerciseSets = sets.map { it.toExerciseSetUiModel() }
+    )
+}
+
+fun SharedRoutineExerciseSet.toExerciseSetUiModel(): ExerciseSetUiModel {
+    return ExerciseSetUiModel(
+        setId = setId,
+        exerciseId = exerciseId,
+        weight = weight,
+        count = count,
+        order = order
     )
 }

--- a/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
+++ b/app/src/main/java/com/lateinit/rightweight/util/Mappers.kt
@@ -1,27 +1,19 @@
 package com.lateinit.rightweight.util
 
-import com.lateinit.rightweight.data.database.entity.Day
-import com.lateinit.rightweight.data.database.entity.Exercise
-import com.lateinit.rightweight.data.database.entity.ExerciseSet
-import com.lateinit.rightweight.data.database.entity.HistorySet
-import com.lateinit.rightweight.data.database.entity.SharedRoutine
-import com.lateinit.rightweight.data.database.entity.Routine
 import com.lateinit.rightweight.data.ExercisePartType
+import com.lateinit.rightweight.data.database.entity.*
 import com.lateinit.rightweight.data.database.intermediate.ExerciseWithSets
 import com.lateinit.rightweight.data.database.intermediate.HistoryExerciseWithHistorySets
 import com.lateinit.rightweight.data.database.intermediate.HistoryWithHistoryExercises
 import com.lateinit.rightweight.data.database.intermediate.SharedRoutineExerciseWithExerciseSets
 import com.lateinit.rightweight.data.model.DetailResponse
+import com.lateinit.rightweight.data.remote.model.*
 import com.lateinit.rightweight.ui.model.DayUiModel
 import com.lateinit.rightweight.ui.model.ExerciseSetUiModel
 import com.lateinit.rightweight.ui.model.ExerciseUiModel
 import com.lateinit.rightweight.ui.model.HistoryExerciseSetUiModel
 import com.lateinit.rightweight.ui.model.HistoryExerciseUiModel
 import com.lateinit.rightweight.ui.model.HistoryUiModel
-import com.lateinit.rightweight.data.remote.model.SharedRoutineDayField
-import com.lateinit.rightweight.data.remote.model.SharedRoutineExerciseField
-import com.lateinit.rightweight.data.remote.model.SharedRoutineExerciseSetField
-import com.lateinit.rightweight.data.remote.model.SharedRoutineField
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -175,16 +167,16 @@ fun ExerciseSetUiModel.toExerciseSetField(): ExerciseSetField {
     )
 }
 
-fun DetailResponse<SharedRoutineDayField>.toSharedRoutineDay(): SharedRoutineDay {
+fun DetailResponse<DayField>.toSharedRoutineDay(): SharedRoutineDay {
     val splitedName = name.split("/")
     return SharedRoutineDay(
-        routineId = fields.routine_id?.value.toString(),
+        routineId = fields.routineId?.value.toString(),
         dayId = splitedName.last(),
         order = fields.order?.value.toString().toInt()
     )
 }
 
-fun DetailResponse<SharedRoutineExerciseField>.toSharedRoutineExercise(): SharedRoutineExercise {
+fun DetailResponse<ExerciseField>.toSharedRoutineExercise(): SharedRoutineExercise {
     val splitedName = name.split("/")
     return SharedRoutineExercise(
         dayId = fields.dayId?.value.toString(),
@@ -196,7 +188,7 @@ fun DetailResponse<SharedRoutineExerciseField>.toSharedRoutineExercise(): Shared
     )
 }
 
-fun DetailResponse<SharedRoutineExerciseSetField>.toSharedRoutineExerciseSet(): SharedRoutineExerciseSet {
+fun DetailResponse<ExerciseSetField>.toSharedRoutineExerciseSet(): SharedRoutineExerciseSet {
     val splitedName = name.split("/")
     return SharedRoutineExerciseSet(
         exerciseId = fields.exerciseId?.value.toString(),

--- a/app/src/main/res/layout/fragment_shared_routine_detail.xml
+++ b/app/src/main/res/layout/fragment_shared_routine_detail.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
+        <import type="java.time.format.DateTimeFormatter" />
         <variable
             name="sharedRoutine"
             type="com.lateinit.rightweight.data.database.entity.SharedRoutine" />
@@ -29,6 +29,50 @@
                 android:layout_height="match_parent">
 
                 <TextView
+                    android:id="@+id/text_view_author_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="@string/shared_routine_author"
+                    android:textAppearance="@style/Text.Medium.Bold"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/text_view_author"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:layout_marginStart="10dp"
+                    android:text="@{sharedRoutine.author}"
+                    android:textAppearance="@style/Text.Medium.Bold"
+                    app:layout_constraintStart_toEndOf = "@id/text_view_author_label"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="author"/>
+
+                <TextView
+                    android:id="@+id/text_view_modified_date_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="@string/shared_routine_modified_date"
+                    android:textAppearance="@style/Text.Medium.Bold"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/text_view_author_label" />
+
+                <TextView
+                    android:id="@+id/text_view_modified_date"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:layout_marginStart="10dp"
+                    android:text="@{sharedRoutine.modifiedDate.format(DateTimeFormatter.ofPattern(@string/date_format))}"
+                    android:textAppearance="@style/Text.Medium.Bold"
+                    app:layout_constraintStart_toEndOf = "@id/text_view_modified_date_label"
+                    app:layout_constraintTop_toBottomOf="@id/text_view_author_label"
+                    tools:text="2022-12-01"/>
+
+                <TextView
                     android:id="@+id/text_view_title_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -36,7 +80,7 @@
                     android:text="@string/routine_title"
                     android:textAppearance="@style/Text.Medium.Bold"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    app:layout_constraintTop_toBottomOf="@id/text_view_modified_date_label" />
 
                 <TextView
                     android:id="@+id/text_view_title"

--- a/app/src/main/res/layout/fragment_shared_routine_detail.xml
+++ b/app/src/main/res/layout/fragment_shared_routine_detail.xml
@@ -1,18 +1,107 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.share.detail.SharedRoutineDetailFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <Button
-        android:id="@+id/copy"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="루틴 가져오기"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.routine.detail.RoutineDetailFragment">
+
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:paddingHorizontal="16dp"
+            app:layout_constraintBottom_toTopOf="@id/button_routine_select"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TextView
+                    android:id="@+id/text_view_title_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="@string/routine_title"
+                    android:textAppearance="@style/Text.Medium.Bold"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/text_view_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text=""
+                    android:textAppearance="@style/Text.Medium"
+                    app:layout_constraintStart_toStartOf="@+id/text_view_title_label"
+                    app:layout_constraintTop_toBottomOf="@+id/text_view_title_label"
+                    tools:text="Strength 5x5" />
+
+                <TextView
+                    android:id="@+id/text_view_description_label"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/routine_description"
+                    android:textAppearance="@style/Text.Medium"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/text_view_title" />
+
+                <TextView
+                    android:id="@+id/text_view_description"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text=""
+                    android:textAppearance="@style/Text.Medium"
+                    app:layout_constraintStart_toStartOf="@+id/text_view_description_label"
+                    app:layout_constraintTop_toBottomOf="@+id/text_view_description_label"
+                    tools:text="이 훈련법은 스트렝스의 증가에 목적을 두고..." />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/recycler_view_day"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:orientation="horizontal"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/text_view_description"
+                    tools:listitem="@layout/item_day" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/recycler_view_exercise"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:orientation="vertical"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/recycler_view_day"
+                    tools:itemCount="3"
+                    tools:listitem="@layout/item_exercise_with_sets" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.core.widget.NestedScrollView>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/button_routine_select"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:padding="16dp"
+            android:text="@string/routine_copy"
+            android:textColor="@color/white"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_shared_routine_detail.xml
+++ b/app/src/main/res/layout/fragment_shared_routine_detail.xml
@@ -5,6 +5,9 @@
 
     <data>
 
+        <variable
+            name="sharedRoutine"
+            type="com.lateinit.rightweight.data.database.entity.SharedRoutine" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -39,7 +42,7 @@
                     android:id="@+id/text_view_title"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text=""
+                    android:text="@{sharedRoutine.title}"
                     android:textAppearance="@style/Text.Medium"
                     app:layout_constraintStart_toStartOf="@+id/text_view_title_label"
                     app:layout_constraintTop_toBottomOf="@+id/text_view_title_label"
@@ -59,7 +62,7 @@
                     android:id="@+id/text_view_description"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:text=""
+                    android:text="@{sharedRoutine.description}"
                     android:textAppearance="@style/Text.Medium"
                     app:layout_constraintStart_toStartOf="@+id/text_view_description_label"
                     app:layout_constraintTop_toBottomOf="@+id/text_view_description_label"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,9 @@
     <string name="routine_title">루틴 명</string>
     <string name="routine_description">설명</string>
     <string name="routine_save">루틴 저장하기</string>
+    <string name="shared_routine_author">작성자</string>
+    <string name="shared_routine_modified_date">작성일</string>
+    <string name="shared_routine_download_count">다운로드 수</string>
     <string name="chest">가슴</string>
     <string name="back">등</string>
     <string name="leg">하체</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
     <string name="move_up">위로</string>
     <string name="move_down">아래로</string>
     <string name="routine_select">루틴 선택 하기</string>
+    <string name="routine_copy">복사하여 내 루틴목록으로 가져오기</string>
     <string name="expand">확장</string>
     <string name="exercise_time">운동한 시간: %s</string>
     <string name="history_none">운동기록이 없습니다.</string>


### PR DESCRIPTION
- close #100 

### 구현 내용

#### 커뮤니티 화면  -> 공유된 루틴 열람 화면 이동 시 bundle로 routine id 전달
#### 공유된 루틴 열람 화면 진입 후 routine id에 관련된 자세한 정보(day, exercise, exerciseSet 목록) 요청
#### 요청 시 Room에서 캐싱된 목록이 있는지 확인 후 routine id와 연결된 day가 하나도 캐싱되어 있지 않으면 firestore 서버에 요청하여 Room에 캐싱
#### Room에 캐싱된 목록을 viewmodel과 Flow로 연결하여 가져오고, DayUiModel 형태로 변경하여 uiState.Success에 SharedRoutine과 List<DayUiModel>을 저장
#### fragment는 flow 형태의 uiState를 collect 하여 ui 업데이트

### 구현 화면

[sprint3 주말 테스트.webm](https://user-images.githubusercontent.com/75258748/205508090-89599908-74d5-4893-abfd-b8b6ed2cba01.webm)

