### PR TITLE
[루틴 생성/수정 화면] 루틴 생성/수정 시 작성자명 반영, 레이아웃 수정

### DIFF
--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailFragment.kt
@@ -1,7 +1,12 @@
 package com.lateinit.rightweight.ui.routine.detail
 
 import android.os.Bundle
-import android.view.*
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
@@ -76,7 +81,7 @@ class RoutineDetailFragment : Fragment() {
                     R.id.action_item_edit -> {
                         val action =
                             RoutineDetailFragmentDirections.actionNavigationRoutineDetailToNavigationRoutineEditor(
-                                args.routineId
+                                routineId = args.routineId
                             )
                         findNavController().navigate(action)
                         return true

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/editor/RoutineEditorViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/editor/RoutineEditorViewModel.kt
@@ -7,14 +7,13 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
-import com.lateinit.rightweight.data.ExercisePartType
-import com.lateinit.rightweight.data.database.entity.Routine
 import com.lateinit.rightweight.data.repository.RoutineRepository
 import com.lateinit.rightweight.ui.model.DayUiModel
 import com.lateinit.rightweight.ui.model.ExercisePartTypeUiModel
 import com.lateinit.rightweight.ui.model.ExerciseSetUiModel
 import com.lateinit.rightweight.ui.model.ExerciseUiModel
 import com.lateinit.rightweight.ui.model.RoutineUiModel
+import com.lateinit.rightweight.util.DEFAULT_AUTHOR_NAME
 import com.lateinit.rightweight.util.FIRST_DAY_POSITION
 import com.lateinit.rightweight.util.toDay
 import com.lateinit.rightweight.util.toDayUiModel
@@ -37,6 +36,7 @@ class RoutineEditorViewModel @Inject constructor(
 ) : ViewModel() {
 
     private var routineId: String
+    private var routineAuthor = DEFAULT_AUTHOR_NAME
 
     val routineTitle = MutableLiveData<String>()
     val routineDescription = MutableLiveData<String>()
@@ -73,10 +73,11 @@ class RoutineEditorViewModel @Inject constructor(
     val isPossibleSaveRoutine = _isPossibleSaveRoutine.asSharedFlow()
 
     init {
-        this.routineId = savedStateHandle.get<String>("routineId") ?: DEFAULT_ROUTINE_ID
+        routineId = savedStateHandle.get<String>("routineId") ?: DEFAULT_ROUTINE_ID
 
         if (routineId.isEmpty()) {
-            this.routineId = createUUID()
+            routineId = createUUID()
+            routineAuthor = savedStateHandle.get<String>("author") ?: DEFAULT_AUTHOR_NAME
             addDay()
         } else {
             getRoutine(routineId)
@@ -236,7 +237,7 @@ class RoutineEditorViewModel @Inject constructor(
             }
 
             routineRepository.insertRoutine(
-                RoutineUiModel(routineId, title, "author", description, LocalDateTime.now(), order),
+                RoutineUiModel(routineId, title, routineAuthor, description, LocalDateTime.now(), order),
                 days.map { it.toDay() },
                 exercises.map { it.toExercise() },
                 exerciseSets.map { it.toExerciseSet() }
@@ -266,6 +267,7 @@ class RoutineEditorViewModel @Inject constructor(
                 routineTitle.value = title
                 routineDescription.value = description
                 routineOrder.value = order
+                routineAuthor = author
             }
             mapDayToExercise(dayUiModels)
             mapExerciseToSet(dayUiModels.flatMap { it.exercises })

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/management/RoutineManagementFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/management/RoutineManagementFragment.kt
@@ -7,8 +7,8 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.lateinit.rightweight.R
 import com.lateinit.rightweight.databinding.FragmentRoutineManagementBinding
+import com.lateinit.rightweight.util.DEFAULT_AUTHOR_NAME
 import com.lateinit.rightweight.util.collectOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -84,7 +84,12 @@ class RoutineManagementFragment : Fragment() {
     }
 
     private fun navigateToRoutineEditor() {
-        findNavController().navigate(R.id.action_navigation_routine_management_to_navigation_routine_editor)
+        val author = viewModel.userInfo.value?.displayName ?: DEFAULT_AUTHOR_NAME
+        val action =
+            RoutineManagementFragmentDirections.actionNavigationRoutineManagementToNavigationRoutineEditor(
+                author = author
+            )
+        findNavController().navigate(action)
     }
 
     private fun navigateToRoutineDetail(routineId: String) {

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/management/RoutineManagementViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/management/RoutineManagementViewModel.kt
@@ -22,7 +22,7 @@ class RoutineManagementViewModel @Inject constructor(
     private val routineRepository: RoutineRepository
 ) : ViewModel() {
 
-    private val userInfo =
+    val userInfo =
         userRepository.getUser().stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     private val _selectedRoutineUiModel = MutableStateFlow<RoutineUiModel?>(null)

--- a/app/src/main/java/com/lateinit/rightweight/util/Consts.kt
+++ b/app/src/main/java/com/lateinit/rightweight/util/Consts.kt
@@ -3,3 +3,4 @@ package com.lateinit.rightweight.util
 const val FIRST_DAY_POSITION = 0
 const val DEFAULT_SET_WEIGHT = "0"
 const val DEFAULT_SET_COUNT = "0"
+const val DEFAULT_AUTHOR_NAME = ""

--- a/app/src/main/res/layout/fragment_routine_editor.xml
+++ b/app/src/main/res/layout/fragment_routine_editor.xml
@@ -44,6 +44,8 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
+                    app:counterEnabled="true"
+                    app:counterMaxLength="20"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/text_view_title">
@@ -53,6 +55,8 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:hint="@string/input_routine_name"
+                        android:inputType="text"
+                        android:maxLength="20"
                         android:text="@={viewModel.routineTitle}"
                         android:textAppearance="@style/Text.Small" />
 
@@ -62,7 +66,6 @@
                     android:id="@+id/text_view_description"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="20dp"
                     android:text="@string/routine_description"
                     android:textAppearance="@style/Text.Medium.Bold"
                     app:layout_constraintStart_toStartOf="parent"
@@ -106,12 +109,13 @@
                     style="@style/Text.Small.Bold"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
                     android:onClick="@{()->viewModel.removeDay()}"
                     android:text="@string/day_remove"
                     android:textColor="@color/white"
                     app:layout_constraintEnd_toStartOf="@id/button_add_day"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/recycler_view_day" />
+                    app:layout_constraintTop_toBottomOf="@id/recycler_view_day" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/button_add_day"
@@ -121,9 +125,10 @@
                     android:onClick="@{()->viewModel.addDay()}"
                     android:text="@string/day_add"
                     android:textColor="@color/white"
+                    app:layout_constraintBottom_toBottomOf="@id/button_remove_day"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@id/button_remove_day"
-                    app:layout_constraintTop_toBottomOf="@+id/recycler_view_day" />
+                    app:layout_constraintTop_toTopOf="@id/button_remove_day" />
 
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/recycler_view_exercise"
@@ -134,7 +139,7 @@
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/button_remove_day"
+                    app:layout_constraintTop_toBottomOf="@id/button_remove_day"
                     tools:itemCount="2"
                     tools:listitem="@layout/item_exercise" />
 
@@ -153,7 +158,7 @@
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/recycler_view_exercise" />
+                    app:layout_constraintTop_toBottomOf="@id/recycler_view_exercise" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.core.widget.NestedScrollView>
 
@@ -164,6 +169,7 @@
             android:layout_marginHorizontal="16dp"
             android:onClick="@{() -> viewModel.saveRoutine()}"
             android:padding="16dp"
+            android:stateListAnimator="@null"
             android:text="@string/routine_save"
             android:textColor="@color/white"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_routine_editor.xml
+++ b/app/src/main/res/layout/fragment_routine_editor.xml
@@ -167,6 +167,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="16dp"
+            android:insetTop="0dp"
             android:onClick="@{() -> viewModel.saveRoutine()}"
             android:padding="16dp"
             android:stateListAnimator="@null"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -62,6 +62,11 @@
             android:defaultValue=""
             app:argType="string" />
 
+        <argument
+            android:name="author"
+            android:defaultValue=""
+            app:argType="string" />
+
     </fragment>
     <fragment
         android:id="@+id/navigation_shared_routine_detail"


### PR DESCRIPTION
- close #135 

## 동작 화면

[untitled.webm](https://user-images.githubusercontent.com/64251968/206386249-64b89b1c-d545-4f92-a5dc-3f612434753a.webm)

## 작업 내용

- 루틴 생성 시 작성자 명이 사용자의 displayName으로 저장되도록 변경
- 루틴명 글자 수 제한 추가
- day 목록과 day추가, 제거 버튼 간격 조정
- 루틴 저장 버튼 클릭 시 부자연스러운 그림자 제거
- 루틴 저장 버튼 위 공백 제거