### PR TITLE
[History 사용 화면] History가 있는 루틴 삭제 시 꺼지는 버그 수정, routineId 프로퍼티 제거

### DIFF
--- a/app/src/main/java/com/lateinit/rightweight/data/database/entity/History.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/entity/History.kt
@@ -2,20 +2,10 @@ package com.lateinit.rightweight.data.database.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
-import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
 import java.time.LocalDate
 
-@Entity(
-    tableName = "history",
-    foreignKeys = [
-        ForeignKey(
-            entity = Routine::class,
-            parentColumns = ["routine_id"],
-            childColumns = ["routine_id"]
-        )
-    ]
-)
+@Entity(tableName = "history")
 data class History(
     @PrimaryKey
     @ColumnInfo(name = "history_id")
@@ -29,7 +19,5 @@ data class History(
     @ColumnInfo(name = "day_order")
     val dayOrder: Int,
     @ColumnInfo(name = "completed")
-    val completed: Boolean,
-    @ColumnInfo(name = "routine_id")
-    val routineId: String
+    val completed: Boolean
 )

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/local/impl/HistoryLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/local/impl/HistoryLocalDataSourceImpl.kt
@@ -27,7 +27,7 @@ class HistoryLocalDataSourceImpl @Inject constructor(
         exerciseSets: List<ExerciseSet>
     ) {
         val historyId = createRandomUUID()
-        val history = History(historyId, LocalDate.now(), "00:00:00", routineTitle, day.order, false, routineId)
+        val history = History(historyId, LocalDate.now(), "00:00:00", routineTitle, day.order, false)
         val historyExercises = mutableListOf<HistoryExercise>()
         val historySets = mutableListOf<HistorySet>()
         for(exercise in exercises){

--- a/app/src/main/java/com/lateinit/rightweight/data/mapper/local/ToHistory.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/mapper/local/ToHistory.kt
@@ -16,8 +16,7 @@ fun HistoryUiModel.toHistory(): History {
         time = time,
         routineTitle = routineTitle,
         dayOrder = order,
-        completed = completed,
-        routineId = routineId
+        completed = completed
     )
 }
 

--- a/app/src/main/java/com/lateinit/rightweight/data/mapper/remote/ToHisttoryField.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/mapper/remote/ToHisttoryField.kt
@@ -15,8 +15,7 @@ fun HistoryUiModel.toHistoryField(): HistoryField {
         date = TimeStampValue(date.toString() + "T00:00:00Z"),
         time = StringValue(time),
         routineTitle = StringValue(routineTitle),
-        order = IntValue(order.toString()),
-        routineId = StringValue(routineId)
+        order = IntValue(order.toString())
     )
 }
 

--- a/app/src/main/java/com/lateinit/rightweight/data/model/remote/RemoteData.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/model/remote/RemoteData.kt
@@ -106,9 +106,7 @@ data class HistoryField(
     @SerializedName("routine_title")
     val routineTitle: StringValue,
     @SerializedName("order")
-    val order: IntValue,
-    @SerializedName("routine_id")
-    val routineId: StringValue,
+    val order: IntValue
 ) : RemoteData()
 
 data class HistoryExerciseField(

--- a/app/src/main/java/com/lateinit/rightweight/ui/mapper/HistoryUiModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/mapper/HistoryUiModel.kt
@@ -15,7 +15,6 @@ fun HistoryWithHistoryExercises.toHistoryUiModel(): HistoryUiModel {
         routineTitle = history.routineTitle,
         order = history.dayOrder,
         completed = history.completed,
-        routineId = history.routineId,
         exercises = historyExercises.map { it.toHistoryExerciseUiModel() }
     )
 }

--- a/app/src/main/java/com/lateinit/rightweight/ui/model/history/HistoryUiModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/model/history/HistoryUiModel.kt
@@ -10,6 +10,5 @@ data class HistoryUiModel(
     val routineTitle: String,
     override val order: Int,
     val completed: Boolean,
-    val routineId: String,
     override val exercises: List<HistoryExerciseUiModel>
 ) : ParentDayUiModel(order, exercises)


### PR DESCRIPTION
- close #161 

## 작업 내용

- History, HistoryField에서 routineId 프로퍼티 제거
- History, HistoryField의 routineId 사용 코드 제거
- routineId 제거로 인해 Foreign Key 제약이 사라져 기록이 있는 루틴 삭제 시 꺼지는 버그가 수정되었습니다.