### PR TITLE
[유저정보 복원] 운동 기록 복원

### DIFF
--- a/app/src/main/java/com/lateinit/rightweight/data/api/UserApiService.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/api/UserApiService.kt
@@ -5,6 +5,8 @@ import com.lateinit.rightweight.data.model.remote.DocumentResponse
 import com.lateinit.rightweight.data.model.remote.DocumentsResponse
 import com.lateinit.rightweight.data.model.remote.RunQueryBody
 import com.lateinit.rightweight.data.model.remote.WriteRequestBody
+import com.lateinit.rightweight.data.remote.model.HistoryExerciseField
+import com.lateinit.rightweight.data.remote.model.HistoryExerciseSetField
 import com.lateinit.rightweight.data.remote.model.HistoryField
 import com.lateinit.rightweight.data.remote.model.RemoteData
 import com.lateinit.rightweight.data.remote.model.RootField
@@ -35,12 +37,29 @@ interface UserApiService {
         path: String
     ): DocumentsResponse<DetailResponse<RemoteData>>
 
-
     @POST("documents/user/{userId}/:runQuery")
     suspend fun getLastHistoryDate(
         @Path(value = "userId", encoded = true) userId: String,
         @Body query: RunQueryBody
     ): List<DocumentResponse<HistoryField>>
+
+    @GET("documents/{path}")
+    suspend fun getHistories(
+        @Path(value = "path", encoded = true)
+        path: String
+    ): DocumentsResponse<HistoryField>
+
+    @GET("documents/{path}")
+    suspend fun getHistoryExercises(
+        @Path(value = "path", encoded = true)
+        path: String
+    ): DocumentsResponse<HistoryExerciseField>
+
+    @GET("documents/{path}")
+    suspend fun getHistoryExerciseSets(
+        @Path(value = "path", encoded = true)
+        path: String
+    ): DocumentsResponse<HistoryExerciseSetField>
 
     @GET("documents/user/{userId}")
     suspend fun restoreUserInfo(

--- a/app/src/main/java/com/lateinit/rightweight/data/database/dao/HistoryDao.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/dao/HistoryDao.kt
@@ -24,6 +24,13 @@ interface HistoryDao {
     )
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertHistories(
+        history: List<History>,
+        exercises: List<HistoryExercise>,
+        sets: List<HistorySet>
+    )
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertHistorySet(set: HistorySet)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -72,4 +79,13 @@ interface HistoryDao {
 
     @Query("DELETE FROM history")
     suspend fun removeAllHistories()
+
+    @Transaction
+    suspend fun restoreRoutine(
+        histories: List<History>,
+        exercises: List<HistoryExercise>,
+        sets: List<HistorySet>
+    ){
+        insertHistories(histories,exercises,sets)
+    }
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/database/dao/HistoryDao.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/dao/HistoryDao.kt
@@ -23,8 +23,8 @@ interface HistoryDao {
         sets: List<HistorySet>
     )
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertHistories(
+    @Insert
+    suspend fun restoreHistory(
         history: List<History>,
         exercises: List<HistoryExercise>,
         sets: List<HistorySet>
@@ -80,12 +80,4 @@ interface HistoryDao {
     @Query("DELETE FROM history")
     suspend fun removeAllHistories()
 
-    @Transaction
-    suspend fun restoreHistory(
-        histories: List<History>,
-        exercises: List<HistoryExercise>,
-        sets: List<HistorySet>
-    ){
-        insertHistories(histories,exercises,sets)
-    }
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/database/dao/HistoryDao.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/database/dao/HistoryDao.kt
@@ -81,7 +81,7 @@ interface HistoryDao {
     suspend fun removeAllHistories()
 
     @Transaction
-    suspend fun restoreRoutine(
+    suspend fun restoreHistory(
         histories: List<History>,
         exercises: List<HistoryExercise>,
         sets: List<HistorySet>

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/local/HistoryLocalDataSource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/local/HistoryLocalDataSource.kt
@@ -20,6 +20,12 @@ interface HistoryLocalDataSource {
         exerciseSets: List<ExerciseSet>
     )
 
+    suspend fun restoreHistory(
+        histories: List<History>,
+        exercises: List<HistoryExercise>,
+        sets: List<HistorySet>
+    )
+
     suspend fun insertHistorySet(historyExerciseId: String)
 
     suspend fun insertHistoryExercise(historyId: String)

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/local/impl/HistoryLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/local/impl/HistoryLocalDataSourceImpl.kt
@@ -17,7 +17,7 @@ import javax.inject.Inject
 
 class HistoryLocalDataSourceImpl @Inject constructor(
     private val historyDao: HistoryDao
-): HistoryLocalDataSource {
+) : HistoryLocalDataSource {
 
     override suspend fun insertHistory(
         routineId: String,
@@ -27,23 +27,52 @@ class HistoryLocalDataSourceImpl @Inject constructor(
         exerciseSets: List<ExerciseSet>
     ) {
         val historyId = createRandomUUID()
-        val history = History(historyId, LocalDate.now(), "00:00:00", routineTitle, day.order, false, routineId)
+        val history = History(
+            historyId,
+            LocalDate.now(),
+            "00:00:00",
+            routineTitle,
+            day.order,
+            false,
+            routineId
+        )
         val historyExercises = mutableListOf<HistoryExercise>()
         val historySets = mutableListOf<HistorySet>()
-        for(exercise in exercises){
+        for (exercise in exercises) {
             val historyExerciseId = createRandomUUID()
-            val historyExercise = HistoryExercise(historyExerciseId, historyId, exercise.title, exercise.order, exercise.part)
+            val historyExercise = HistoryExercise(
+                historyExerciseId,
+                historyId,
+                exercise.title,
+                exercise.order,
+                exercise.part
+            )
             historyExercises.add(historyExercise)
-            for(exerciseSet in exerciseSets){
-                if(exerciseSet.exerciseId == exercise.exerciseId){
+            for (exerciseSet in exerciseSets) {
+                if (exerciseSet.exerciseId == exercise.exerciseId) {
                     val historySetId = createRandomUUID()
-                    val historySet = HistorySet(historySetId, historyExerciseId, exerciseSet.weight, exerciseSet.count, exerciseSet.order, false)
+                    val historySet = HistorySet(
+                        historySetId,
+                        historyExerciseId,
+                        exerciseSet.weight,
+                        exerciseSet.count,
+                        exerciseSet.order,
+                        false
+                    )
                     historySets.add(historySet)
                 }
             }
         }
 
         historyDao.insertHistory(history, historyExercises, historySets)
+    }
+
+    override suspend fun restoreHistory(
+        histories: List<History>,
+        exercises: List<HistoryExercise>,
+        sets: List<HistorySet>
+    ) {
+        historyDao.restoreHistory(histories, exercises, sets)
     }
 
     override suspend fun insertHistorySet(historyExerciseId: String) {

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/remote/HistoryRemoteDatasource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/remote/HistoryRemoteDatasource.kt
@@ -1,7 +1,16 @@
 package com.lateinit.rightweight.data.datasource.remote
 
+import com.lateinit.rightweight.data.database.entity.History
+import com.lateinit.rightweight.data.database.entity.HistoryExercise
+import com.lateinit.rightweight.data.database.entity.HistorySet
 import java.time.LocalDate
 
 interface HistoryRemoteDatasource {
     suspend fun getLatestHistoryDate(userId: String): LocalDate
+
+    suspend fun getHistories(routineId: String): List<History>?
+
+    suspend fun getHistoryExercises(path: String): List<HistoryExercise>?
+
+    suspend fun getHistoryExerciseSets(path: String): List<HistorySet>?
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/remote/HistoryRemoteDatasource.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/remote/HistoryRemoteDatasource.kt
@@ -8,9 +8,9 @@ import java.time.LocalDate
 interface HistoryRemoteDatasource {
     suspend fun getLatestHistoryDate(userId: String): LocalDate
 
-    suspend fun getHistories(routineId: String): List<History>?
+    suspend fun getHistories(path: String): List<History>
 
-    suspend fun getHistoryExercises(path: String): List<HistoryExercise>?
+    suspend fun getHistoryExercises(path: String): List<HistoryExercise>
 
-    suspend fun getHistoryExerciseSets(path: String): List<HistorySet>?
+    suspend fun getHistoryExerciseSets(path: String): List<HistorySet>
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/remote/impl/HistoryRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/remote/impl/HistoryRemoteDataSourceImpl.kt
@@ -1,7 +1,13 @@
 package com.lateinit.rightweight.data.datasource.remote.impl
 
 import com.lateinit.rightweight.data.api.UserApiService
+import com.lateinit.rightweight.data.database.entity.History
+import com.lateinit.rightweight.data.database.entity.HistoryExercise
+import com.lateinit.rightweight.data.database.entity.HistorySet
 import com.lateinit.rightweight.data.datasource.remote.HistoryRemoteDatasource
+import com.lateinit.rightweight.data.mapper.toHistory
+import com.lateinit.rightweight.data.mapper.toHistoryExercise
+import com.lateinit.rightweight.data.mapper.toHistorySet
 import com.lateinit.rightweight.data.model.remote.Direction
 import com.lateinit.rightweight.data.model.remote.FiledReferenceData
 import com.lateinit.rightweight.data.model.remote.FromData
@@ -35,6 +41,30 @@ class HistoryRemoteDataSourceImpl @Inject constructor(
         val lastDateTime = documentResponseList.first()
             .document?.fields?.date?.value ?: return DEFAULT_LOCAL_DATE
         return LocalDate.parse(lastDateTime, formatter)
+    }
+
+    override suspend fun getHistories(routineId: String): List<History>? {
+        val histories = api.getHistories(routineId)
+        return histories.documents?.map {
+            val historyId = it.name.split("/").last()
+            it.fields.toHistory(historyId)
+        }
+    }
+
+    override suspend fun getHistoryExercises(path: String): List<HistoryExercise>? {
+        val exercises = api.getHistoryExercises(path)
+        return exercises.documents?.map {
+            val exerciseId = it.name.split("/").last()
+            it.fields.toHistoryExercise(exerciseId)
+        }
+    }
+
+    override suspend fun getHistoryExerciseSets(path: String): List<HistorySet>? {
+        val exerciseSets = api.getHistoryExerciseSets(path)
+        return exerciseSets.documents?.map {
+            val exerciseSetId = it.name.split("/").last()
+            it.fields.toHistorySet(exerciseSetId)
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/lateinit/rightweight/data/datasource/remote/impl/HistoryRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/datasource/remote/impl/HistoryRemoteDataSourceImpl.kt
@@ -43,28 +43,28 @@ class HistoryRemoteDataSourceImpl @Inject constructor(
         return LocalDate.parse(lastDateTime, formatter)
     }
 
-    override suspend fun getHistories(routineId: String): List<History>? {
-        val histories = api.getHistories(routineId)
+    override suspend fun getHistories(path: String): List<History>{
+        val histories = api.getHistories(path)
         return histories.documents?.map {
             val historyId = it.name.split("/").last()
             it.fields.toHistory(historyId)
-        }
+        } ?: emptyList()
     }
 
-    override suspend fun getHistoryExercises(path: String): List<HistoryExercise>? {
+    override suspend fun getHistoryExercises(path: String): List<HistoryExercise> {
         val exercises = api.getHistoryExercises(path)
         return exercises.documents?.map {
             val exerciseId = it.name.split("/").last()
             it.fields.toHistoryExercise(exerciseId)
-        }
+        } ?: emptyList()
     }
 
-    override suspend fun getHistoryExerciseSets(path: String): List<HistorySet>? {
+    override suspend fun getHistoryExerciseSets(path: String): List<HistorySet> {
         val exerciseSets = api.getHistoryExerciseSets(path)
         return exerciseSets.documents?.map {
             val exerciseSetId = it.name.split("/").last()
             it.fields.toHistorySet(exerciseSetId)
-        }
+        } ?: emptyList()
     }
 
     companion object {

--- a/app/src/main/java/com/lateinit/rightweight/data/mapper/local/ToHistory.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/mapper/local/ToHistory.kt
@@ -58,8 +58,7 @@ fun HistoryField.toHistory(historyId: String): History {
         time = time.value,
         routineTitle = routineTitle.value,
         dayOrder = order.value.toInt(),
-        completed = true,
-        routineId = routineId.value
+        completed = true
     )
 }
 

--- a/app/src/main/java/com/lateinit/rightweight/data/mapper/local/ToHistory.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/mapper/local/ToHistory.kt
@@ -50,7 +50,7 @@ fun HistoryExerciseSetUiModel.toHistorySet(): HistorySet {
 
 fun HistoryField.toHistory(historyId: String): History {
     val refinedDateString = date.value
-    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
     val date = LocalDate.parse(refinedDateString, formatter)
 
     return History(

--- a/app/src/main/java/com/lateinit/rightweight/data/mapper/local/ToHistory.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/mapper/local/ToHistory.kt
@@ -3,11 +3,17 @@ package com.lateinit.rightweight.data.mapper
 import com.lateinit.rightweight.data.database.entity.History
 import com.lateinit.rightweight.data.database.entity.HistoryExercise
 import com.lateinit.rightweight.data.database.entity.HistorySet
+import com.lateinit.rightweight.data.model.local.ExercisePartType
+import com.lateinit.rightweight.data.remote.model.HistoryExerciseField
+import com.lateinit.rightweight.data.remote.model.HistoryExerciseSetField
+import com.lateinit.rightweight.data.remote.model.HistoryField
 import com.lateinit.rightweight.ui.model.history.HistoryExerciseSetUiModel
 import com.lateinit.rightweight.ui.model.history.HistoryExerciseUiModel
 import com.lateinit.rightweight.ui.model.history.HistoryUiModel
 import com.lateinit.rightweight.util.DEFAULT_SET_COUNT
 import com.lateinit.rightweight.util.DEFAULT_SET_WEIGHT
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 fun HistoryUiModel.toHistory(): History {
     return History(
@@ -39,5 +45,42 @@ fun HistoryExerciseSetUiModel.toHistorySet(): HistorySet {
         count = count.ifEmpty { DEFAULT_SET_COUNT },
         order = order,
         checked = checked
+    )
+}
+
+fun HistoryField.toHistory(historyId: String): History {
+    val refinedDateString = date.value
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    val date = LocalDate.parse(refinedDateString, formatter)
+
+    return History(
+        historyId = historyId,
+        date = date,
+        time = time.value,
+        routineTitle = routineTitle.value,
+        dayOrder = order.value.toInt(),
+        completed = true,
+        routineId = routineId.value
+    )
+}
+
+fun HistoryExerciseField.toHistoryExercise(exerciseId: String): HistoryExercise {
+    return HistoryExercise(
+        exerciseId = exerciseId,
+        historyId = historyId.value,
+        title = title.value,
+        order = order.value.toInt(),
+        part = ExercisePartType.valueOf(part.value)
+    )
+}
+
+fun HistoryExerciseSetField.toHistorySet(exerciseSetId: String): HistorySet {
+    return HistorySet(
+        setId = exerciseSetId,
+        exerciseId = exerciseId.value,
+        weight = weight.value,
+        count = count.value,
+        order = order.value.toInt(),
+        checked = true
     )
 }

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/HistoryRepository.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/HistoryRepository.kt
@@ -29,6 +29,8 @@ interface HistoryRepository {
 
     suspend fun getHistoryAfterDate(startDate: LocalDate): List<HistoryUiModel>
 
+    suspend fun restoreHistory(userId: String, historyIds: List<String>)
+
     fun getHistoryByDate(localDate: LocalDate): Flow<History>
 
     fun getHistoryWithHistoryExercisesByDate(localDate: LocalDate): Flow<HistoryWithHistoryExercises?>

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/HistoryRepository.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/HistoryRepository.kt
@@ -29,7 +29,7 @@ interface HistoryRepository {
 
     suspend fun getHistoryAfterDate(startDate: LocalDate): List<HistoryUiModel>
 
-    suspend fun restoreHistory(userId: String, historyIds: List<String>)
+    suspend fun restoreHistory(userId: String)
 
     fun getHistoryByDate(localDate: LocalDate): Flow<History>
 

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/impl/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/impl/HistoryRepositoryImpl.kt
@@ -75,6 +75,7 @@ class HistoryRepositoryImpl @Inject constructor(
                 historyRemoteDatasource.getHistoryExerciseSets(path)
             )
         }
+        historyLocalDataSource.restoreHistory(histories,historyExercises,historySets)
     }
 
     override fun getHistoryByDate(localDate: LocalDate): Flow<History> {

--- a/app/src/main/java/com/lateinit/rightweight/data/repository/impl/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/com/lateinit/rightweight/data/repository/impl/HistoryRepositoryImpl.kt
@@ -58,7 +58,7 @@ class HistoryRepositoryImpl @Inject constructor(
         return historyLocalDataSource.getHistoryAfterDate(startDate).map { it.toHistoryUiModel() }
     }
 
-    override suspend fun restoreHistory(userId: String, historyIds: List<String>) {
+    override suspend fun restoreHistory(userId: String) {
         var path = "user/${userId}/history"
         val histories = historyRemoteDatasource.getHistories(path)
         val historyExercises = mutableListOf<HistoryExercise>()

--- a/app/src/main/java/com/lateinit/rightweight/ui/MainViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/MainViewModel.kt
@@ -101,16 +101,16 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch() {
             val userInfoInServer = userRepository.restoreUserInfo(userId)
             if(userInfoInServer != null){
-                restoreRoutine(userId)
-                restoreUserInfo(
-                    userInfoInServer.routineId.value,
-                    userInfoInServer.dayId.value
-                )
+                restoreHistory(userId)
+//                restoreUserInfo(
+//                    userInfoInServer.routineId.value,
+//                    userInfoInServer.dayId.value
+//                )
             }
         }
     }
 
-    private suspend fun restoreRoutine(userId: String) {
+    private suspend fun restoreHistory(userId: String) {
         historyRepository.restoreHistory(userId)
     }
 

--- a/app/src/main/java/com/lateinit/rightweight/ui/MainViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/MainViewModel.kt
@@ -101,12 +101,17 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch() {
             val userInfoInServer = userRepository.restoreUserInfo(userId)
             if(userInfoInServer != null){
+                restoreRoutine(userId)
                 restoreUserInfo(
                     userInfoInServer.routineId.value,
                     userInfoInServer.dayId.value
                 )
             }
         }
+    }
+
+    private suspend fun restoreRoutine(userId: String) {
+        historyRepository.restoreHistory(userId)
     }
 
     private suspend fun restoreUserInfo(routineId: String, datId: String) {


### PR DESCRIPTION
- close #173 


## 동작 화면
https://user-images.githubusercontent.com/54586491/206893871-b75062ed-ed54-44b4-9454-743efd17c4ba.mp4

로그인 과정에서 서버에 백업된 데이터를 받아와 로컬에 저장을 해준다.

## 작업 내용
- 운동기록 Field값을 entity값으로 바꾸는 mapper 구현
- 사용자 ID를 바탕으로 해당 User의 운동 기록을 모두 가져옴
- 각 운동 기록을 room에 저장