### PR TITLE
[루틴 열람 화면] 운동 정보 접고 펴는 기능 미동작 버그 수정

### DIFF
--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailViewModel.kt
@@ -126,6 +126,7 @@ class RoutineDetailViewModel @Inject constructor(
             originDayUiModels[nowDayPosition].copy(exercises = originExerciseUiModels)
 
         _dayUiModels.value = originDayUiModels
+        _currentDayPosition.value = _currentDayPosition.value
     }
 
     fun removeRoutine(routineId: String) {


### PR DESCRIPTION
- close #162 

## 작업 내용

- currentDayPosition 갱신 코드를 다시 추가하여 운동 정보 접고 펴는 기능이 동작하지 않던 버그를 수정했습니다.