### PR TITLE
[모든 화면] 공통 부분 리팩토링

### DIFF
--- a/app/src/main/java/com/lateinit/rightweight/ui/MainActivity.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/MainActivity.kt
@@ -16,8 +16,6 @@ import androidx.core.view.GravityCompat
 import androidx.databinding.DataBindingUtil
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
@@ -41,7 +39,6 @@ import com.lateinit.rightweight.ui.login.LoginActivity
 import com.lateinit.rightweight.ui.login.NetworkState
 import com.lateinit.rightweight.util.collectOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelectedListener {
@@ -174,12 +171,10 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         // set drawer header
         val headerBinding = NavigationHeaderBinding.bind(binding.navigationView.getHeaderView(0))
 
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.CREATED) {
-                viewModel.userInfo.collect {
-                    it?.let {
-                        headerBinding.user = it
-                    }
+        collectOnLifecycle(Lifecycle.State.CREATED) {
+            viewModel.userInfo.collect {
+                it?.let {
+                    headerBinding.user = it
                 }
             }
         }

--- a/app/src/main/java/com/lateinit/rightweight/ui/exercise/ExerciseFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/exercise/ExerciseFragment.kt
@@ -177,7 +177,10 @@ class ExerciseFragment : Fragment() {
         }
 
         historyExerciseAdapter = HistoryExerciseAdapter(exercisePartAdapter, historyEventListener)
-        binding.recyclerViewHistory.adapter = historyExerciseAdapter
+        binding.recyclerViewHistory.apply {
+            adapter = historyExerciseAdapter
+            itemAnimator = null
+        }
     }
 
     private fun collectHistory() {

--- a/app/src/main/java/com/lateinit/rightweight/ui/exercise/ExerciseFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/exercise/ExerciseFragment.kt
@@ -181,7 +181,7 @@ class ExerciseFragment : Fragment() {
     }
 
     private fun collectHistory() {
-        collectOnLifecycle {
+        viewLifecycleOwner.collectOnLifecycle {
             viewModel.historyUiModel.collect {
                 it ?: return@collect
 
@@ -199,7 +199,7 @@ class ExerciseFragment : Fragment() {
     }
 
     private fun handleNavigationEvent() {
-        collectOnLifecycle {
+        viewLifecycleOwner.collectOnLifecycle {
             viewModel.navigationEvent.collect {
                 findNavController().navigateUp()
             }

--- a/app/src/main/java/com/lateinit/rightweight/ui/exercise/HistoryExerciseAdapter.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/exercise/HistoryExerciseAdapter.kt
@@ -72,8 +72,13 @@ class HistoryExerciseAdapter(
                 binding.root.context.getString(historyExerciseUiModel.part.partName)
             binding.textViewExercisePart.setText(exercisePartName, false)
 
-            binding.recyclerViewSet.adapter = historySetAdapter
+            binding.recyclerViewSet.apply {
+                adapter = historySetAdapter
+                itemAnimator = null
+            }
             historySetAdapter.submitList(historyExerciseUiModel.exerciseSets)
+
+            binding.executePendingBindings()
         }
     }
 

--- a/app/src/main/java/com/lateinit/rightweight/ui/exercise/HistorySetAdapter.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/exercise/HistorySetAdapter.kt
@@ -59,6 +59,7 @@ class HistorySetAdapter(
         fun bind(historyExerciseSetUiModel: HistoryExerciseSetUiModel) {
             this.historyExerciseSetUiModel = historyExerciseSetUiModel
             binding.historyExerciseSetUiModel = historyExerciseSetUiModel
+            binding.executePendingBindings()
         }
     }
 

--- a/app/src/main/java/com/lateinit/rightweight/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/home/HomeFragment.kt
@@ -23,7 +23,9 @@ class HomeFragment : Fragment() {
     private var _binding: FragmentHomeBinding? = null
     private val binding
         get() = checkNotNull(_binding) { "binding was accessed outside of view lifecycle" }
+
     private val viewModel: HomeViewModel by viewModels()
+
     private lateinit var adapter: ConcatAdapter
     private val dialog: CommonDialogFragment by lazy {
         CommonDialogFragment{ tag ->
@@ -40,21 +42,14 @@ class HomeFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentHomeBinding.inflate(inflater, container, false)
-
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
         setBinding()
         setListeners()
         collectSelectedDay()
-    }
-
-    override fun onDestroyView() {
-        _binding = null
-        super.onDestroyView()
     }
 
     private fun setBinding() {
@@ -82,7 +77,7 @@ class HomeFragment : Fragment() {
     }
 
     private fun collectSelectedDay() {
-        collectOnLifecycle {
+        viewLifecycleOwner.collectOnLifecycle {
             viewModel.selectedDay.collect { dayUiModel ->
                 setAdapter(dayUiModel)
             }
@@ -98,5 +93,10 @@ class HomeFragment : Fragment() {
         adapter = ConcatAdapter(homeAdapters)
         binding.layoutDayExercises.recyclerViewTodayRoutine.adapter = adapter
         binding.layoutDayExercises.recyclerViewTodayRoutine.itemAnimator = ExpandableItemAnimator()
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 }

--- a/app/src/main/java/com/lateinit/rightweight/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/home/HomeFragment.kt
@@ -91,8 +91,10 @@ class HomeFragment : Fragment() {
         }
 
         adapter = ConcatAdapter(homeAdapters)
-        binding.layoutDayExercises.recyclerViewTodayRoutine.adapter = adapter
-        binding.layoutDayExercises.recyclerViewTodayRoutine.itemAnimator = ExpandableItemAnimator()
+        binding.layoutDayExercises.recyclerViewTodayRoutine.apply {
+            adapter = adapter
+            itemAnimator = ExpandableItemAnimator()
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/lateinit/rightweight/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/login/LoginActivity.kt
@@ -14,8 +14,6 @@ import androidx.core.animation.doOnStart
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
@@ -25,8 +23,8 @@ import com.google.android.material.snackbar.Snackbar
 import com.lateinit.rightweight.R
 import com.lateinit.rightweight.databinding.ActivityLoginBinding
 import com.lateinit.rightweight.ui.MainActivity
+import com.lateinit.rightweight.util.collectOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class LoginActivity : AppCompatActivity() {
@@ -60,14 +58,14 @@ class LoginActivity : AppCompatActivity() {
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        setSplachScreen()
+        setSplashScreen()
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this@LoginActivity, R.layout.activity_login)
         setLoginButtonListener()
         collectNetworkResponse()
     }
 
-    private fun setSplachScreen(){
+    private fun setSplashScreen(){
         installSplashScreen().setOnExitAnimationListener{ splashScreenViewProvider ->
             ObjectAnimator.ofFloat(splashScreenViewProvider.view, View.ALPHA, 1f, 0f).run {
                 interpolator = AnticipateInterpolator()
@@ -88,7 +86,6 @@ class LoginActivity : AppCompatActivity() {
             moveToHomeActivity(true)
         }
     }
-
 
     private fun setLoginButtonListener() {
         binding.buttonGoogleLogin.setOnClickListener {
@@ -113,26 +110,24 @@ class LoginActivity : AppCompatActivity() {
     }
 
     private fun collectNetworkResponse() {
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.CREATED) {
-                loginViewModel.networkResult.collect { networkResult ->
-                    when (networkResult) {
-                        NetworkState.NO_ERROR -> {}
-                        NetworkState.BAD_INTERNET -> {
-                            Snackbar.make(binding.root, "인터넷 상태 나쁨", Snackbar.LENGTH_LONG).show()
-                        }
-                        NetworkState.PARSE_ERROR -> {
-                            Snackbar.make(binding.root, "파싱 오류", Snackbar.LENGTH_LONG).show()
-                        }
-                        NetworkState.WRONG_CONNECTION -> {
-                            Snackbar.make(binding.root, "인터넷 연결 오류", Snackbar.LENGTH_LONG).show()
-                        }
-                        NetworkState.OTHER_ERROR -> {
-                            Snackbar.make(binding.root, "예상치 못한 오류", Snackbar.LENGTH_LONG).show()
-                        }
-                        NetworkState.SUCCESS -> {
-                            moveToHomeActivity(false)
-                        }
+        collectOnLifecycle(Lifecycle.State.CREATED) {
+            loginViewModel.networkResult.collect { networkResult ->
+                when (networkResult) {
+                    NetworkState.NO_ERROR -> {}
+                    NetworkState.BAD_INTERNET -> {
+                        Snackbar.make(binding.root, "인터넷 상태 나쁨", Snackbar.LENGTH_LONG).show()
+                    }
+                    NetworkState.PARSE_ERROR -> {
+                        Snackbar.make(binding.root, "파싱 오류", Snackbar.LENGTH_LONG).show()
+                    }
+                    NetworkState.WRONG_CONNECTION -> {
+                        Snackbar.make(binding.root, "인터넷 연결 오류", Snackbar.LENGTH_LONG).show()
+                    }
+                    NetworkState.OTHER_ERROR -> {
+                        Snackbar.make(binding.root, "예상치 못한 오류", Snackbar.LENGTH_LONG).show()
+                    }
+                    NetworkState.SUCCESS -> {
+                        moveToHomeActivity(false)
                     }
                 }
             }

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/DetailExerciseAdapter.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/DetailExerciseAdapter.kt
@@ -48,9 +48,14 @@ class DetailExerciseAdapter(
             this.exerciseUiModel = exerciseUiModel
             binding.exerciseUiModel = exerciseUiModel
 
-            binding.recyclerViewSet.adapter = detailExerciseSetAdapter
+            binding.recyclerViewSet.apply {
+                adapter = detailExerciseSetAdapter
+                itemAnimator = null
+            }
             val exerciseSets = exerciseUiModel.exerciseSets
             detailExerciseSetAdapter.submitList(exerciseSets)
+
+            binding.executePendingBindings()
         }
     }
 

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/DetailExerciseSetAdapter.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/DetailExerciseSetAdapter.kt
@@ -27,6 +27,7 @@ class DetailExerciseSetAdapter :
 
         fun bind(exerciseSetUiModel: ExerciseSetUiModel) {
             binding.exerciseSetUiModel = exerciseSetUiModel
+            binding.executePendingBindings()
         }
     }
 

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailFragment.kt
@@ -142,7 +142,7 @@ class RoutineDetailFragment : Fragment() {
     }
 
     private fun handleNavigationEvent() {
-        collectOnLifecycle {
+        viewLifecycleOwner.collectOnLifecycle {
             viewModel.navigationEvent.collect { event ->
                 when (event) {
                     is RoutineDetailViewModel.NavigationEvent.SelectEvent -> {
@@ -163,7 +163,7 @@ class RoutineDetailFragment : Fragment() {
     }
 
     private fun handleNetworkResultEvent() {
-        collectOnLifecycle {
+        viewLifecycleOwner.collectOnLifecycle {
             viewModel.networkState.collect { state ->
                 if (state == NetworkState.SUCCESS) {
                     Snackbar.make(

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailFragment.kt
@@ -15,7 +15,6 @@ import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.fragment.navArgs
 import com.google.android.material.snackbar.Snackbar
 import com.lateinit.rightweight.R
 import com.lateinit.rightweight.databinding.FragmentRoutineDetailBinding
@@ -34,8 +33,6 @@ class RoutineDetailFragment : Fragment() {
     private val binding
         get() = checkNotNull(_binding) { "binding was accessed outside of view lifecycle" }
 
-    private val args: RoutineDetailFragmentArgs by navArgs()
-
     private val viewModel: RoutineDetailViewModel by viewModels()
 
     private lateinit var routineDayAdapter: RoutineDayAdapter
@@ -45,10 +42,10 @@ class RoutineDetailFragment : Fragment() {
             when (dialog.tag) {
                 SELECTED_ROUTINE_REMOVE_DIALOG_TAG -> {
                     viewModel.deselectRoutine()
-                    viewModel.removeRoutine(args.routineId)
+                    viewModel.removeRoutine()
                 }
                 ROUTINE_REMOVE_DIALOG_TAG -> {
-                    viewModel.removeRoutine(args.routineId)
+                    viewModel.removeRoutine()
                 }
             }
         }
@@ -64,7 +61,6 @@ class RoutineDetailFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel.getRoutine(args.routineId)
         setMenu()
         setBinding()
         setRoutineDayAdapter()
@@ -87,13 +83,13 @@ class RoutineDetailFragment : Fragment() {
                     R.id.action_item_edit -> {
                         val action =
                             RoutineDetailFragmentDirections.actionNavigationRoutineDetailToNavigationRoutineEditor(
-                                routineId = args.routineId
+                                routineId = viewModel.routineId
                             )
                         findNavController().navigate(action)
                         return true
                     }
                     R.id.action_item_remove -> {
-                        removeRoutine(args.routineId)
+                        removeRoutine()
                         return true
                     }
                     R.id.action_item_share -> {
@@ -193,9 +189,9 @@ class RoutineDetailFragment : Fragment() {
     }
 
 
-    private fun removeRoutine(routineId: String) {
+    private fun removeRoutine() {
         val selectedRoutineId = viewModel.userInfo.value?.routineId
-        if (selectedRoutineId != routineId) {
+        if (selectedRoutineId != viewModel.routineId) {
             dialog.show(
                 parentFragmentManager,
                 ROUTINE_REMOVE_DIALOG_TAG,

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/detail/RoutineDetailFragment.kt
@@ -117,7 +117,10 @@ class RoutineDetailFragment : Fragment() {
     private fun setRoutineDayAdapter() {
         routineDayAdapter =
             RoutineDayAdapter { position -> viewModel.clickDay(position) }
-        binding.recyclerViewDay.adapter = routineDayAdapter
+        binding.recyclerViewDay.apply {
+            adapter = routineDayAdapter
+            itemAnimator = null
+        }
     }
 
     private fun setDayUiModelsObserve() {
@@ -130,7 +133,10 @@ class RoutineDetailFragment : Fragment() {
         exerciseAdapter = DetailExerciseAdapter { position ->
             viewModel.clickExercise(position)
         }
-        binding.recyclerViewExercise.adapter = exerciseAdapter
+        binding.recyclerViewExercise.apply {
+            adapter = exerciseAdapter
+            itemAnimator = null
+        }
     }
 
     private fun setCurrentDayPositionObserve() {

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/editor/RoutineEditorFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/editor/RoutineEditorFragment.kt
@@ -106,7 +106,7 @@ class RoutineEditorFragment : Fragment() {
     }
 
     private fun setRoutineSaveButtonEvent() {
-        collectOnLifecycle {
+        viewLifecycleOwner.collectOnLifecycle {
             viewModel.isPossibleSaveRoutine.collect {
                 when (it) {
                     RoutineSaveState.SUCCESS -> {

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/editor/RoutineEditorViewModel.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/editor/RoutineEditorViewModel.kt
@@ -20,6 +20,7 @@ import com.lateinit.rightweight.ui.model.routine.ExerciseSetUiModel
 import com.lateinit.rightweight.ui.model.routine.ExerciseUiModel
 import com.lateinit.rightweight.ui.model.routine.RoutineUiModel
 import com.lateinit.rightweight.util.DEFAULT_AUTHOR_NAME
+import com.lateinit.rightweight.util.DEFAULT_ROUTINE_ID
 import com.lateinit.rightweight.util.FIRST_DAY_POSITION
 import com.lateinit.rightweight.util.createRandomUUID
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -355,7 +356,6 @@ class RoutineEditorViewModel @Inject constructor(
 
     companion object {
         private const val DEFAULT_EXERCISE_TITLE = ""
-        private const val DEFAULT_ROUTINE_ID = ""
         private const val MAX_DAY_SIZE = 10
         private const val MAX_EXERCISE_SIZE = 10
         private const val MAX_EXERCISE_SET_SIZE = 10

--- a/app/src/main/java/com/lateinit/rightweight/ui/routine/management/RoutineManagementFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/routine/management/RoutineManagementFragment.kt
@@ -99,7 +99,7 @@ class RoutineManagementFragment : Fragment() {
     }
 
     private fun collectRoutines() {
-        collectOnLifecycle {
+        viewLifecycleOwner.collectOnLifecycle {
             viewModel.routineUiModels.collect {
                 routineAdapter.submitList(it)
             }

--- a/app/src/main/java/com/lateinit/rightweight/ui/share/detail/SharedRoutineDetailFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/share/detail/SharedRoutineDetailFragment.kt
@@ -56,14 +56,20 @@ class SharedRoutineDetailFragment : Fragment() {
             RoutineDayAdapter { position ->
                 viewModel.clickDay(position)
             }
-        binding.recyclerViewDay.adapter = routineDayAdapter
+        binding.recyclerViewDay.apply {
+            adapter = routineDayAdapter
+            itemAnimator = null
+        }
     }
 
     private fun setExerciseAdapter() {
         exerciseAdapter = DetailExerciseAdapter { position ->
             viewModel.clickExercise(position)
         }
-        binding.recyclerViewExercise.adapter = exerciseAdapter
+        binding.recyclerViewExercise.apply {
+            adapter = exerciseAdapter
+            itemAnimator = null
+        }
     }
 
     private fun setSharedRoutineDetailCollect() {

--- a/app/src/main/java/com/lateinit/rightweight/ui/share/detail/SharedRoutineDetailFragment.kt
+++ b/app/src/main/java/com/lateinit/rightweight/ui/share/detail/SharedRoutineDetailFragment.kt
@@ -67,7 +67,7 @@ class SharedRoutineDetailFragment : Fragment() {
     }
 
     private fun setSharedRoutineDetailCollect() {
-        collectOnLifecycle {
+        viewLifecycleOwner.collectOnLifecycle {
             viewModel.uiState.collect { uiState ->
                 when (uiState) {
                     is LatestSharedRoutineDetailUiState.Success -> {
@@ -99,7 +99,7 @@ class SharedRoutineDetailFragment : Fragment() {
     }
 
     private fun handleNavigationEvent() {
-        collectOnLifecycle {
+        viewLifecycleOwner.collectOnLifecycle {
             viewModel.navigationEvent.collect { 
                 setFragmentResult("routineCopy", bundleOf())
                 findNavController().navigateUp()

--- a/app/src/main/java/com/lateinit/rightweight/util/Consts.kt
+++ b/app/src/main/java/com/lateinit/rightweight/util/Consts.kt
@@ -4,3 +4,4 @@ const val FIRST_DAY_POSITION = 0
 const val DEFAULT_SET_WEIGHT = "0"
 const val DEFAULT_SET_COUNT = "0"
 const val DEFAULT_AUTHOR_NAME = ""
+const val DEFAULT_ROUTINE_ID = ""


### PR DESCRIPTION
- close #185 

## 작업 내용

- 프래그먼트에서 flow 수집 확장함수의 lifecycleOwner를 viewLifecycleOwner로 변경
- flow 수집 코드 정의한 확장함수를 사용하도록 변경
- 아이템 애니메이터 불필요한 부분 제거
- 리사이클러뷰 어댑터 executePendingBinding() 추가
- safe args 값을 viewModel에서 savedStateHandle로 받아서 바로 쓸 수 있게 변경